### PR TITLE
Toevoegen documentatie die naar browsable api-spec wijst

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ De volgende documenten beschrijven dit project:
 - Product Owner: [@ehotting](https://github.com/ehotting)
 - Scrum Master:  [@TCIMEddy](https://github.com/TCIMEddy)
 
+## API spec bekijken
+
+Zie de relevante [links](./docs/content/spec.md).
+
 ## Licentie
 Copyright © VNG Realisatie 2018
 

--- a/docs/content/spec.md
+++ b/docs/content/spec.md
@@ -1,0 +1,29 @@
+# API specificaties
+
+De `master` versie specificaties worden via Swagger.io inzichtelijk gemaakt.
+
+Merk op dat de specificatie op dit moment nog heel erg aan verandering
+onderhevig is.
+
+De specificaties voor de verschillende componenten leven in
+`api-specificatie/<component>/openapi.yaml`.
+
+## Zaakregistratiecomponent
+
+In de ZRC worden ZAAKen geregistreerd.
+
+Bekijk de [zrc spec](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/zrc/openapi.yaml)
+
+## Zaaktypecataloguscomponent
+
+De zaaktypecataloguscomponent bevat informatie over beschikbare ZAAKTYPEn
+en daaruit volgende gegevens die het verloop van een ZAAK (kunnen) bepalen.
+
+Bekijk de [ztc spec](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/openapi.yaml)
+
+
+## Documentregistratiecomponent
+
+In de DRC worden INFORMATIEOBJECTen voor ZAAKen vastgelegd.
+
+Spec: TODO


### PR DESCRIPTION
Dit helpt in ieder geval bij de DoD requirements:

> - er is een OAS 3.0 specificatie, afgestemd met leveranciers van ZRC/e-Suite
> - de specificatie is gepubliceerd leesbaar

Op die manier kunnen we in ieder geval de 'gepubliceerde' specificatie in de browser bekijken, wat het reviewen ook wat makkelijk maakt, en het dev-straat gedeelte isoleert van de specifieke user stories.