### PR TITLE
API versie parameter aan paths toegevoegd

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -1,12 +1,12 @@
 openapi: "3.0.0"
 info:
   title: Zaak registratie API
-  description: Een API om een zaak registratie component te kunnen benaderen
+  description: Een API om een zaakregistratiecomponent te kunnen benaderen
   version: 1.0.0
   contact:
     url:  https://github.com/VNG-Realisatie/gemma-zaken
 paths:
-  /zaken:
+  '/api/v{version}/zaken':
     post:
       summary: Aanmaken nieuwe zaak
       operationId: aanmakenZaak
@@ -35,14 +35,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Fout'
-  /zaken/{zaakid}/informatieobjecten:
     parameters:
-      - name: zaakid
+      - name: version
         in: path
         required: true
-        description: zaakidentificatie
         schema:
           type: string
+  '/api/v{version}/zaken/{zaakid}/informatieobjecten':
     post:
       summary: Voeg een informatieobject toe aan de zaak
       operationId: toevoegenInformatieobject
@@ -72,6 +71,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Fout'
+    parameters:
+      - name: version
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: zaakid
+        in: path
+        required: true
+        description: zaakidentificatie
+        schema:
+          type: string
+servers:
+  - url: /
 components:
   schemas:
     Zaak:
@@ -114,7 +127,7 @@ components:
     ZaakId:
       description: zaakidentificatie
       properties:
-        zaakidentificatie: 
+        zaakidentificatie:
           type: string
           description: zaakidentificatie
     Subject:
@@ -193,8 +206,3 @@ components:
             reason:
               description: Wat er mis is met de inhoud van de parameter
               type: string
-  links:
-    ToevoegenInformatieobject:
-      operationId: toevoegenInformatieobject
-      parameters:
-        zaak-uuid: $response.body#/zaak-uuid

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -1,12 +1,12 @@
 openapi: "3.0.0"
 info:
   title: Zaaktype catalogus API
-  description: Een API om het zaaktype catalogus component te benaderen
+  description: Een API om een zaaktypecataloguscomponent te benaderen
   version: 1.0.0
   contact:
     url:  https://github.com/VNG-Realisatie/gemma-zaken
 paths:
-  /zaaktypes/{zaaktype-id}:
+  'api/v{version}/zaaktypes/{zaaktype-id}':
     get:
       summary: Ophalen van een zaaktype via het id
       operationId: ophalenZaaktype
@@ -29,7 +29,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Fout'
-  /zaaktypes/{zaaktype-id}/statussen/{status-id}:
+    parameters:
+      - name: version
+        in: path
+        required: true
+        schema:
+          type: string
+  'api/v{version}/zaaktypes/{zaaktype-id}/statussen/{status-id}':
     get:
       summary: Ophalen van een zaak status via het zaaktype id en status id
       operationId: ophalenZaakstatus
@@ -57,6 +63,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Fout'
+    parameters:
+      - name: version
+        in: path
+        required: true
+        schema:
+          type: string
+servers:
+  - url: /
 components:
   schemas:
     Zaaktype:
@@ -90,4 +104,3 @@ components:
           type: string
     Fout:
       description: Een opgetreden fout
-


### PR DESCRIPTION
* Sluit beter aan op de DSO URI-strategie
* Laat ons toe om in de toekomst backward-incompatible changes door
  te voeren indien nodig
* Algemene best practice

Daarnaast:
* `.editorconfig` toegevoegd zodat er een standaard formaat is (2-space indent voor yaml bijvoorbeeld)
* Kleine beschrijvingsaanpassingen
* Servers toevoegd met `/` als root - we kunnen geen domeinnamen/protocollen definieren
* `link` component weggehaald - er zijn geen referenties (meer) naar