### PR TITLE
Verplaats informatieobjecten spec naar DRC, focus op koppelen in ZRC

### DIFF
--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -1,0 +1,57 @@
+openapi: "3.0.0"
+info:
+  title: Document management systeem API
+  description: Een API om een documentregistratiecomponent te benaderen
+  version: 0.0.1
+  contact:
+    url:  https://github.com/VNG-Realisatie/gemma-zaken
+paths:
+  '/api/v{version}/informatieobjecten':
+    get:
+      operationId: informatieobject_list
+      description: Ophalen van informatieobjecten
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InformatieObject'
+    parameters:
+      - name: version
+        in: path
+        required: true
+        schema:
+          type: string
+servers:
+  - url: /
+components:
+  schemas:
+    InformatieObject:
+      description: Een informatieobject (document, foto...)
+      required:
+      - titel
+      - type
+      - mimetype
+      - inhoud
+      properties:
+        id:
+          description: ID van het informatieobject
+          type: string
+        titel:
+          description: Titel van het informatieobject
+          type: string
+        status:
+          description: Status van het informatieobject
+          type: string
+        type:
+          description: Type van het informatieobject
+          type: string
+        mimetype:
+          description: Minetype van het informatieobject
+          type: string
+        inhoud:
+          description: Inhoud van het informatieobject (base64 encoded)
+          type: string

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -41,26 +41,25 @@ paths:
         required: true
         schema:
           type: string
-  '/api/v{version}/zaken/{zaakid}/informatieobjecten':
+  '/api/v{version}/zaakinformatieobjecten':
     post:
       summary: Voeg een informatieobject toe aan de zaak
-      operationId: toevoegenInformatieobject
-      description: Voeg een informatieobject toe aan de zaak
+      operationId: zaakinformatieobject_create
+      description: Voeg een informatieobject toe aan een zaak
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Informatieobject'
+              $ref: '#/components/schemas/ZaakInformatieObject'
       responses:
         201:
-          description: Informatieobject is succesvol aangemaakt.
+          description: ZaakInformatieObject is succesvol aangemaakt.
           content:
             application/json:
               schema:
-                type: string
-                description: Zaak identificatie toegekend aan de nieuwe zaak.
+                $ref: '#/components/schema/ZaakInformatieObject'
         422:
-          description: Opgegeven informatieobject kan niet verwerkt worden
+          description: Opgegeven zaakinformatieobject kan niet verwerkt worden
           content:
             application/json:
               schema:
@@ -75,12 +74,6 @@ paths:
       - name: version
         in: path
         required: true
-        schema:
-          type: string
-      - name: zaakid
-        in: path
-        required: true
-        description: zaakidentificatie
         schema:
           type: string
 servers:
@@ -162,28 +155,22 @@ components:
       - naam
       - waarde
       - type
-    Informatieobject:
-      description: Een aan de zaak gerelateerd informatie object (document, foto end.)
-      properties:
-        titel:
-          description: Titel van het informatieobject
-          type: string
-        status:
-          description: Status van het informatieobject
-          type: string
-        type:
-          description: Type van het informatieobject
-          type: string
-        mimetype:
-          description: Minetype van het informatieobject
-          type: string
-        inhoud:
-          description: Inhoud van het informatieobject
+    ZaakInformatieObject:
       required:
-      - titel
-      - type
-      - mimetype
-      - inhoud
+        - zaak
+        - informatieobject
+      description: Een aan een zaak gerelateerd informatieobject (document, foto end.)
+      properties:
+        zaak:
+          title: Zaak
+          description: URL naar de zaak horend bij dit ZAAKINFORMATIEOBJECT
+          type: string
+          format: uri
+        informatieobject:
+          title: informatieobject
+          description: URL naar het informatieobject horend bij dit ZAAKINFORMATIEOBJECT
+          type: string
+          format: uri
     Fout:
       description: Een opgetreden fout
       properties:

--- a/docs/content/spec.md
+++ b/docs/content/spec.md
@@ -26,4 +26,4 @@ Bekijk de [ztc spec](http://petstore.swagger.io/?url=https://raw.githubuserconte
 
 In de DRC worden INFORMATIEOBJECTen voor ZAAKen vastgelegd.
 
-Spec: TODO
+Bekijk de [drc spec](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/drc/openapi.yaml)


### PR DESCRIPTION
Opmerking: dit bouwt op #128, deze moet dus eerste gemerged worden.

De eerste voorzet van Andy nam informatieobjecten op in het ZRC, maar als we de DRC (voorheen DMS) component (vb. Alfresco) beschouwen, dan hoort dit hier niet thuis.

De informatieobjecten zelf worden in het DRC vastgelegd, de link tussen een informatieobject en een zaak wordt in het ZRC vastgelegd.

Dit zou conform RGBZ 2.0 en GEMMA 2.0 moeten zijn.