### PR TITLE
Aanpassingen aan aanmaken ZAAK & Schema ZAAK

### DIFF
--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -9,8 +9,12 @@ paths:
   '/api/v{version}/zaken':
     post:
       summary: Aanmaken nieuwe zaak
-      operationId: aanmakenZaak
-      description: Maakt een nieuwe zaak aan en retourneert de toegekende zaak identificatie wanneer de zaak succesvol is aangemaakt.
+      operationId: zaak_create
+      description: >-
+        Maak een ZAAK aan.
+
+        Indien geen zaakidentificatie gegeven is, dan wordt deze automatisch
+        gegenereerd.
       requestBody:
         content:
           application/json:
@@ -18,11 +22,11 @@ paths:
               $ref: '#/components/schemas/Zaak'
       responses:
         201:
-          description: "Zaakidentificatie"
+          description: "Representatie van aangemaakte ZAAK"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ZaakId'
+                $ref: '#/components/schemas/Zaak'
         422:
           description: Opgegeven zaak informatie kan niet verwerkt worden
           content:
@@ -81,80 +85,66 @@ servers:
 components:
   schemas:
     Zaak:
-      description: Een zaak
+      description: Een ZAAK
+      required:
+        - zaaktype
+      type: object
       properties:
-        type:
-          description: URL naar het zaaktype van de zaak
+        url:
+          title: Url
           type: string
-        omschrijving:
-          description: Omschrijving of toelichting op de zaak
+          format: uri
+          readOnly: true
+        zaakidentificatie:
+          title: Zaakidentificatie
+          description: >-
+            De unieke identificatie van de ZAAK binnen de organisatie die
+            verantwoordelijk is voor de behandeling van de ZAAK.
           type: string
-        initiator:
-          $ref: '#/components/schemas/Subject'
+          maxLength: 40
+        zaaktype:
+          title: Zaaktype
+          description: URL naar het zaaktype in de CATALOGUS waar deze voorkomt
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
         status:
-          description: URL naar de status van de zaak
+          title: Status
+          description: 'Indien geen status bekend is, dan is de waarde ''null'''
           type: string
+          format: uri
+          readOnly: true
+        omschrijving:
+          title: Omschrijving
+          description: Een korte omschrijving van de zaak.
+          type: string
+          maxLength: 80
+        # TODO: in het RGBZ 2.0 model loopt dit via de rollen/betrokkenen
+        # initiator:
+        #   title: Initiator
+        #   description: URL naar de initiator van de ZAAK.
+        #   type: string
+        #   format: url
         registratiedatum:
-          description: Tijdstip waarop de zaak is geregistreerd
+          title: Registratiedatum
+          description: De datum waarop de zaakbehandelende organisatie de ZAAK heeft geregistreerd
           type: string
-          format: 'date-time'
-        kanaal:
-          description: Kanaal via welke de zaak is gemeld
-          type: string
-        locatie:
-          description: Coordinate van de locatie waarop de zaak betrekking heeft in Well Known Text (WKT) formaat
+          format: 'date'
+        # TODO: volgens RGBZ 2.0 komt kanaal uit KLANTCONTACT
+        # kanaal:
+        #   description: Kanaal via welke de zaak is gemeld
+        #   type: string
+        zaakgeometrie:  # NOTE: komt ook voor bij OBJECT
+          title: Zaakgeometrie
+          description: Punt, lijn of multi-vlak geometrie-informatie, in WKT formaat.
           type: string
         objecten:
+          title: OBJECTen
           description: Lijst met URL's naar aan de zaak gerelateerde objecten
           type: array
           items:
             type: string
-        zaakgegevens:
-          description: Domein specifieke gegevens beheorende bij de zaak
-          type: array
-          items:
-            $ref: '#/components/schemas/Zaakgegeven'
-      required:
-      - type
-      - omschrijving
-    ZaakId:
-      description: zaakidentificatie
-      properties:
-        zaakidentificatie:
-          type: string
-          description: zaakidentificatie
-    Subject:
-      description: Een persoon of bedrijf
-      properties:
-        email:
-          description: e-mail adres
-          type: string
-          format: email
-        telefoonnummer:
-          description: telefoonnummer
-          type: string
-    Zaakgegeven:
-      description: Domein specifiek gegeven behorende bij een zaak
-      properties:
-        naam:
-          description: Naam van het gegeven
-          type: string
-        waarde:
-          description: Waarde van het gegeven
-          type: string
-        type:
-          description: Type van de waarde van het gegeven
-          type: string
-          enum:
-          - tekst
-          - nummer
-          - datum
-          - datumtijd
-          - ja_nee
-      required:
-      - naam
-      - waarde
-      - type
     ZaakInformatieObject:
       required:
         - zaak
@@ -171,6 +161,17 @@ components:
           description: URL naar het informatieobject horend bij dit ZAAKINFORMATIEOBJECT
           type: string
           format: uri
+    # BETROKKENE?
+    # Subject:
+    #   description: Een persoon of bedrijf
+    #   properties:
+    #     email:
+    #       description: e-mail adres
+    #       type: string
+    #       format: email
+    #     telefoonnummer:
+    #       description: telefoonnummer
+    #       type: string
     Fout:
       description: Een opgetreden fout
       properties:


### PR DESCRIPTION
Opmerking: dit bouwt op #128, deze moet dus eerste gemerged worden.

**Response geeft het (hele) object terug in plaats van enkel identificatie**

Dit laat toe om de client alle relevante gegevens in 1x terug te krijgen van de resource, in plaats van meteen een GET te moeten uitvoeren na de POST. Achter de schermen kan namelijk state aangepast zijn door deze POST.

**client MAG een zaakidentificatie meegeven (moet wel uniek zijn)**

Indien de gegeven zaakidentificatie niet uniek is, dan volgt er een validatie-error (HTTP 400), maar dit laten we voorlopig even buiten scope (zie #130).

**verschillende velden naar juiste(re) RGBZ 2.0 informatiemodel aangepast**

Een aantal velden kregen een naam, terwijl RGBZ 2.0 hiervoor al een attribuut voorziet. In de omgekeerde richting zijn een aantal velden weggehaald die geen RGBZ 2.0 attributen zijn.

Voorbeeld hiervan: Subject/initiator uitgezet, dit loopt normaal via ROLlen en BETROKKENEn in het RGBZ.

**ZaakGegegeven verwijderd - dit lijkt niet te bestaan in het RGBZ.**

Waarschijnlijk moet dit via OBJECT opgelost worden. Ik denk niet dat het handig is om een key-value structuur voor zaken te ondersteunen, puur door het gebrek aan structuur. Het kan een optie worden op de tafel als blijkt dat we voor user-story eisen hier behoefte aan hebben. Dus eigenlijk - laat het ons niet van het begin meenemen en onszelf mogelijk vastrijden.
