### PR TITLE
Fixes #39 - uitbreiding API spec

### DIFF
--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -1,57 +1,194 @@
-openapi: "3.0.0"
+openapi: 3.0.0
 info:
-  title: Document management systeem API
+  title: Documentregistratiecomponent (drc) API
   description: Een API om een documentregistratiecomponent te benaderen
-  version: 0.0.1
   contact:
-    url:  https://github.com/VNG-Realisatie/gemma-zaken
+    url: 'https://github.com/VNG-Realisatie/gemma-zaken'
+    email: support@maykinmedia.nl
+  license:
+    name: EUPL 1.2
+  version: '1'
+security:
+  - basic: []
 paths:
-  '/api/v{version}/informatieobjecten':
-    get:
-      operationId: informatieobject_list
-      description: Ophalen van informatieobjecten
+  /enkelvoudiginformatieobjecten:
+    post:
+      operationId: enkelvoudiginformatieobject_create
+      description: Registreer een EnkelvoudigInformatieObject.
       responses:
-        200:
+        '201':
           description: ''
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/InformatieObject'
+                $ref: '#/components/schemas/EnkelvoudigInformatieObject'
+      tags:
+        - enkelvoudiginformatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnkelvoudigInformatieObject'
+        required: true
+    parameters: []
+  '/enkelvoudiginformatieobjecten/{id}':
+    get:
+      operationId: enkelvoudiginformatieobject_read
+      description: Geef de details van een EnkelvoudigInformatieObject.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnkelvoudigInformatieObject'
+      tags:
+        - enkelvoudiginformatieobjecten
     parameters:
-      - name: version
+      - name: id
         in: path
+        description: A unique integer value identifying this informatieobject.
         required: true
         schema:
-          type: string
+          type: integer
+  /zaakinformatieobjecten:
+    post:
+      operationId: zaakinformatieobject_create
+      description: Registreer een INFORMATIEOBJECT bij een ZAAK.
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+      tags:
+        - zaakinformatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakInformatieObject'
+        required: true
+    parameters: []
+  '/zaakinformatieobjecten/{id}':
+    get:
+      operationId: zaakinformatieobject_read
+      description: Geef de details van een ZAAKINFORMATIEOBJECT relatie.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+      tags:
+        - zaakinformatieobjecten
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this Zaakinformatieobject.
+        required: true
+        schema:
+          type: integer
 servers:
-  - url: /
+  - url: /api/v1
 components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: basic
   schemas:
-    InformatieObject:
-      description: Een informatieobject (document, foto...)
+    EnkelvoudigInformatieObject:
       required:
-      - titel
-      - type
-      - mimetype
-      - inhoud
+        - identificatie
+        - creatiedatum
+        - titel
+        - auteur
+        - taal
+      type: object
       properties:
-        id:
-          description: ID van het informatieobject
+        url:
+          title: Url
           type: string
+          format: uri
+          readOnly: true
+        identificatie:
+          title: Identificatie
+          description: >-
+            Een binnen een gegeven context ondubbelzinnige referentie naar het
+            INFORMATIEOBJECT.
+          type: string
+          maxLength: 40
+          minLength: 1
+        bronorganisatie:
+          title: Bronorganisatie
+          description: >-
+            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die
+            het informatieobject heeft gecreëerd of heeft ontvangen en als
+            eerste in een samenwerkingsketen heeft vastgelegd.
+          type: string
+          maxLength: 9
+        creatiedatum:
+          title: Creatiedatum
+          description: >-
+            Een datum of een gebeurtenis in de levenscyclus van het
+            INFORMATIEOBJECT.
+          type: string
+          format: date
         titel:
-          description: Titel van het informatieobject
+          title: Titel
+          description: De naam waaronder het INFORMATIEOBJECT formeel bekend is.
           type: string
-        status:
-          description: Status van het informatieobject
+          maxLength: 200
+          minLength: 1
+        auteur:
+          title: Auteur
+          description: >-
+            De persoon of organisatie die in de eerste plaats verantwoordelijk
+            is voor het creëren van de inhoud van het INFORMATIEOBJECT.
           type: string
-        type:
-          description: Type van het informatieobject
+          maxLength: 200
+          minLength: 1
+        formaat:
+          title: Formaat
+          description: >-
+            De code voor de wijze waarop de inhoud van het ENKELVOUDIG
+            INFORMATIEOBJECT is vastgelegd in een computerbestand.
           type: string
-        mimetype:
-          description: Minetype van het informatieobject
+          maxLength: 255
+        taal:
+          title: Taal
+          description: >-
+            Een taal van de intellectuele inhoud van het ENKELVOUDIG
+            INFORMATIEOBJECT
           type: string
+          maxLength: 20
+          minLength: 1
         inhoud:
-          description: Inhoud van het informatieobject (base64 encoded)
+          title: Inhoud
           type: string
+          readOnly: true
+          format: uri
+    ZaakInformatieObject:
+      required:
+        - zaak
+        - informatieobject
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          description: URL naar de ZAAK in het ZRC.
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
+        informatieobject:
+          title: Informatieobject
+          type: string
+          format: uri

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: 3.0.0
 info:
   title: Zaak registratie API
   description: Een API om een zaakregistratiecomponent te kunnen benaderen
@@ -195,58 +195,6 @@ paths:
         required: true
         schema:
           type: integer
-  /zaakinformatieobjecten:
-    post:
-      operationId: zaakinformatieobject_create
-      description: Registreer een INFORMATIEOBJECT bij een ZAAK.
-      responses:
-        '201':
-          description: ZaakInformatieObject is succesvol aangemaakt.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZaakInformatieObject'
-        '422':
-          description: Opgegeven zaakinformatieobject kan niet verwerkt worden
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        default:
-          description: Onverwachte fout tijdens opvoeren informatieobject
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-        - zaakinformatieobjecten
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ZaakInformatieObject'
-        required: true
-    parameters: []
-  '/zaakinformatieobjecten/{id}':
-    get:
-      operationId: zaakinformatieobject_read
-      description: Geef de details van een ZAAKINFORMATIEOBJECT relatie.
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZaakInformatieObject'
-      tags:
-        - zaakinformatieobjecten
-    parameters:
-      - name: id
-        in: path
-        description: A unique integer value identifying this Zaakinformatieobject.
-        required: true
-        schema:
-          type: integer
   /zaakobjecten:
     post:
       operationId: zaakobject_create
@@ -348,6 +296,10 @@ paths:
 servers:
   - url: /api/v1
 components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: basic
   schemas:
     OrganisatorischeEenheid:
       required:
@@ -526,30 +478,6 @@ components:
             status van een zaak.
           type: string
           maxLength: 1000
-    ZaakInformatieObject:
-      required:
-        - zaak
-        - informatieobject
-      description: Een aan een zaak gerelateerd informatieobject (document, foto end.)
-      type: object
-      properties:
-        url:
-          title: Url
-          type: string
-          format: uri
-          readOnly: true
-        zaak:
-          title: Zaak
-          description: URL naar de zaak horend bij dit ZAAKINFORMATIEOBJECT
-          type: string
-          format: uri
-        informatieobject:
-          title: Informatieobject
-          description: URL naar het INFORMATIEOBJECT in het DRC.
-          type: string
-          format: uri
-          maxLength: 200
-          minLength: 1
     ZaakObject:
       required:
         - zaak

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -2,62 +2,211 @@ openapi: "3.0.0"
 info:
   title: Zaak registratie API
   description: Een API om een zaakregistratiecomponent te kunnen benaderen
-  version: 1.0.0
   contact:
     url:  https://github.com/VNG-Realisatie/gemma-zaken
+  license:
+    name: EUPL 1.2
+  version: 1.0.0
+security:
+  - basic: []
 paths:
-  /zaken:
+  '/betrokkenen/{id}':
+    get:
+      operationId: organisatorischeeenheid_read
+      description: ''
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganisatorischeEenheid'
+      tags:
+        - betrokkenen
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this Organisatorische eenheid.
+        required: true
+        schema:
+          type: integer
+  /domeindata:
     post:
-      summary: Aanmaken nieuwe zaak
-      operationId: zaak_create
-      description: >-
-        Maak een ZAAK aan.
-
-        Indien geen zaakidentificatie gegeven is, dan wordt deze automatisch
-        gegenereerd.
+      operationId: domeindata_create
+      description: Registreer DOMEINDATA bij een zaak.
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomeinData'
+      tags:
+        - domeindata
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Zaak'
-      responses:
-        201:
-          description: "Representatie van aangemaakte ZAAK"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Zaak'
-        422:
-          description: Opgegeven zaak informatie kan niet verwerkt worden
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        default:
-          description: Onverwachte fout tijdens opvoeren zaak
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fout'
+              $ref: '#/components/schemas/DomeinData'
+        required: true
     parameters: []
+  '/domeindata/{id}':
+    get:
+      operationId: domeindata_read
+      description: Geef de details van DOMEINDATA voor een ZAAK.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomeinData'
+      tags:
+        - domeindata
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this domeindatareferentie.
+        required: true
+        schema:
+          type: integer
+  /klantcontacten:
+    post:
+      operationId: klantcontact_create
+      description: >-
+        Registreer een klantcontact bij een ZAAK.
+
+
+        Indien geen identificatie gegeven is, dan wordt deze automatisch
+        gegenereerd.
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KlantContact'
+      tags:
+        - klantcontacten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KlantContact'
+        required: true
+    parameters: []
+  '/klantcontacten/{id}':
+    get:
+      operationId: klantcontact_read
+      description: Geef de details van een klantcontact voor een ZAAK.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KlantContact'
+      tags:
+        - klantcontacten
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this klantcontact.
+        required: true
+        schema:
+          type: integer
+  /rollen:
+    post:
+      operationId: rol_create
+      description: Koppel een BETROKKENE aan een ZAAK.
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rol'
+      tags:
+        - rollen
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Rol'
+        required: true
+    parameters: []
+  '/rollen/{id}':
+    get:
+      operationId: rol_read
+      description: ''
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rol'
+      tags:
+        - rollen
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this Rol.
+        required: true
+        schema:
+          type: integer
+  /statussen:
+    post:
+      operationId: status_create
+      description: ''
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+      tags:
+        - statussen
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Status'
+        required: true
+    parameters: []
+  '/statussen/{id}':
+    get:
+      operationId: status_read
+      description: ''
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+      tags:
+        - statussen
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this status.
+        required: true
+        schema:
+          type: integer
   /zaakinformatieobjecten:
     post:
-      summary: Voeg een informatieobject toe aan de zaak
       operationId: zaakinformatieobject_create
-      description: Voeg een informatieobject toe aan een zaak
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ZaakInformatieObject'
+      description: Registreer een INFORMATIEOBJECT bij een ZAAK.
       responses:
-        201:
+        '201':
           description: ZaakInformatieObject is succesvol aangemaakt.
           content:
             application/json:
               schema:
-                $ref: '#/components/schema/ZaakInformatieObject'
-        422:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+        '422':
           description: Opgegeven zaakinformatieobject kan niet verwerkt worden
           content:
             application/json:
@@ -69,15 +218,370 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Fout'
+      tags:
+        - zaakinformatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakInformatieObject'
+        required: true
     parameters: []
+  '/zaakinformatieobjecten/{id}':
+    get:
+      operationId: zaakinformatieobject_read
+      description: Geef de details van een ZAAKINFORMATIEOBJECT relatie.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+      tags:
+        - zaakinformatieobjecten
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this Zaakinformatieobject.
+        required: true
+        schema:
+          type: integer
+  /zaakobjecten:
+    post:
+      operationId: zaakobject_create
+      description: Registreer een ZAAKOBJECT relatie.
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+      tags:
+        - zaakobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakObject'
+        required: true
+    parameters: []
+  '/zaakobjecten/{id}':
+    get:
+      operationId: zaakobject_read
+      description: Geef de details van een ZAAKOBJECT relatie.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+      tags:
+        - zaakobjecten
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this zaakobject.
+        required: true
+        schema:
+          type: integer
+  /zaken:
+    post:
+      summary: Aanmaken nieuwe zaak
+      operationId: zaak_create
+      description: >-
+        Maak een ZAAK aan.
+
+
+        Indien geen zaakidentificatie gegeven is, dan wordt deze automatisch
+        gegenereerd.
+      responses:
+        '201':
+          description: "Representatie van aangemaakte ZAAK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Zaak'
+        '422':
+          description: Opgegeven zaak informatie kan niet verwerkt worden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        default:
+          description: Onverwachte fout tijdens opvoeren zaak
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Zaak'
+        required: true
+    parameters: []
+  '/zaken/{id}':
+    get:
+      operationId: zaak_read
+      description: Opvragen en bewerken van ZAAKen.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Zaak'
+      tags:
+        - zaken
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this zaak.
+        required: true
+        schema:
+          type: integer
 servers:
   - url: /api/v1
 components:
   schemas:
+    OrganisatorischeEenheid:
+      required:
+        - organisatieEenheidIdentificatie
+        - organisatieIdentificatie
+        - datumOntstaan
+        - naam
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        organisatieEenheidIdentificatie:
+          title: Organisatie eenheid identificatie
+          description: Een korte identificatie van de organisatorische eenheid.
+          type: string
+          maxLength: 24
+          minLength: 1
+        organisatieIdentificatie:
+          title: Organisatie identificatie
+          description: >-
+            Het RSIN van de organisatie zijnde een Niet-natuurlijk persoon
+            waarvan de ORGANISATORISCHE EENHEID deel uit maakt.
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        datumOntstaan:
+          title: Datum ontstaan
+          description: De datum wrop de organisatorische eenheid is ontstaan.
+          type: string
+          format: date
+        naam:
+          title: Naam
+          description: De feitelijke naam van de organisatorische eenheid.
+          type: string
+          maxLength: 50
+          minLength: 1
+    DomeinData:
+      required:
+        - zaak
+        - domeinData
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          type: string
+          format: uri
+        domeinData:
+          title: Domein data
+          description: URL naar de domein data resource
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
+    KlantContact:
+      required:
+        - zaak
+        - datumtijd
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          type: string
+          format: uri
+        identificatie:
+          title: Identificatie
+          description: De unieke aanduiding van een KLANTCONTACT
+          type: string
+          maxLength: 14
+          minLength: 1
+        datumtijd:
+          title: Datumtijd
+          description: De datum en het tijdstip waarop het KLANTCONTACT begint
+          type: string
+          format: date-time
+        kanaal:
+          title: Kanaal
+          description: Het communicatiekanaal waarlangs het KLANTCONTACT gevoerd wordt
+          type: string
+          maxLength: 20
+    Rol:
+      required:
+        - zaak
+        - betrokkene
+        - rolomschrijving
+        - rolomschrijvingGeneriek
+        - roltoelichting
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          type: string
+          format: uri
+        betrokkene:
+          title: Betrokkene
+          type: string
+          format: uri
+        rolomschrijving:
+          title: Rolomschrijving
+          description: Algemeen gehanteerde benaming van de aard van de ROL
+          type: string
+          enum:
+            - Adviseur
+            - Behandelaar
+            - Belanghebbende
+            - Beslisser
+            - Initiator
+            - Klantcontacter
+            - Zaakcoördinator
+        rolomschrijvingGeneriek:
+          title: Rolomschrijving generiek
+          description: Algemeen gehanteerde benaming van de aard van de ROL
+          type: string
+          enum:
+            - Adviseur
+            - Behandelaar
+            - Belanghebbende
+            - Beslisser
+            - Initiator
+            - Klantcontacter
+            - Zaakcoördinator
+            - Mede-initiator
+        roltoelichting:
+          title: Roltoelichting
+          type: string
+          maxLength: 1000
+          minLength: 1
+    Status:
+      required:
+        - zaak
+        - statusType
+        - datumStatusGezet
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          type: string
+          format: uri
+        statusType:
+          title: Status type
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
+        datumStatusGezet:
+          title: Datum status gezet
+          description: De datum waarop de ZAAK de status heeft verkregen.
+          type: string
+          format: date-time
+        statustoelichting:
+          title: Statustoelichting
+          description: >-
+            Een, voor de initiator van de zaak relevante, toelichting op de
+            status van een zaak.
+          type: string
+          maxLength: 1000
+    ZaakInformatieObject:
+      required:
+        - zaak
+        - informatieobject
+      description: Een aan een zaak gerelateerd informatieobject (document, foto end.)
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          description: URL naar de zaak horend bij dit ZAAKINFORMATIEOBJECT
+          type: string
+          format: uri
+        informatieobject:
+          title: Informatieobject
+          description: URL naar het INFORMATIEOBJECT in het DRC.
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
+    ZaakObject:
+      required:
+        - zaak
+        - object
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          type: string
+          format: uri
+        object:
+          title: Object
+          description: URL naar de resource die het OBJECT beschrijft.
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
+        relatieomschrijving:
+          title: Relatieomschrijving
+          description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
+          type: string
+          maxLength: 80
     Zaak:
       description: Een ZAAK
       required:
         - zaaktype
+        - registratiedatum
       type: object
       properties:
         url:
@@ -99,35 +603,26 @@ components:
           format: uri
           maxLength: 200
           minLength: 1
-        status:
-          title: Status
-          description: 'Indien geen status bekend is, dan is de waarde ''null'''
+        registratiedatum:
+          title: Registratiedatum
+          description: >-
+            De datum waarop de zaakbehandelende organisatie de ZAAK heeft
+            geregistreerd
           type: string
-          format: uri
-          readOnly: true
+          format: date
+        toelichting:
+          title: Toelichting
+          description: Een toelichting op de zaak.
+          type: string
+          maxLength: 1000
         omschrijving:
           title: Omschrijving
           description: Een korte omschrijving van de zaak.
           type: string
           maxLength: 80
-        # TODO: in het RGBZ 2.0 model loopt dit via de rollen/betrokkenen
-        # initiator:
-        #   title: Initiator
-        #   description: URL naar de initiator van de ZAAK.
-        #   type: string
-        #   format: url
-        registratiedatum:
-          title: Registratiedatum
-          description: De datum waarop de zaakbehandelende organisatie de ZAAK heeft geregistreerd
-          type: string
-          format: 'date'
-        # TODO: volgens RGBZ 2.0 komt kanaal uit KLANTCONTACT
-        # kanaal:
-        #   description: Kanaal via welke de zaak is gemeld
-        #   type: string
-        zaakgeometrie:  # NOTE: komt ook voor bij OBJECT
+        zaakgeometrie:
           title: Zaakgeometrie
-          description: Punt, lijn of multi-vlak geometrie-informatie, in WKT formaat.
+          description: 'Punt, lijn of (multi-)vlak geometrie-informatie, in WKT formaat.'
           type: string
         objecten:
           title: OBJECTen
@@ -135,33 +630,12 @@ components:
           type: array
           items:
             type: string
-    ZaakInformatieObject:
-      required:
-        - zaak
-        - informatieobject
-      description: Een aan een zaak gerelateerd informatieobject (document, foto end.)
-      properties:
-        zaak:
-          title: Zaak
-          description: URL naar de zaak horend bij dit ZAAKINFORMATIEOBJECT
+        status:
+          title: Status
+          description: 'Indien geen status bekend is, dan is de waarde ''null'''
           type: string
           format: uri
-        informatieobject:
-          title: informatieobject
-          description: URL naar het informatieobject horend bij dit ZAAKINFORMATIEOBJECT
-          type: string
-          format: uri
-    # BETROKKENE?
-    # Subject:
-    #   description: Een persoon of bedrijf
-    #   properties:
-    #     email:
-    #       description: e-mail adres
-    #       type: string
-    #       format: email
-    #     telefoonnummer:
-    #       description: telefoonnummer
-    #       type: string
+          readOnly: true
     Fout:
       description: Een opgetreden fout
       properties:

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -550,8 +550,8 @@ components:
           maxLength: 80
         zaakgeometrie:
           title: Zaakgeometrie
-          description: 'Punt, lijn of (multi-)vlak geometrie-informatie, in WKT formaat.'
-          type: string
+          description: 'Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON.'
+          type: object
         objecten:
           title: OBJECTen
           description: Lijst met URL's naar aan de zaak gerelateerde objecten

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -1,106 +1,363 @@
-openapi: "3.0.0"
+openapi: 3.0.0
 info:
-  title: Zaaktype catalogus API
-  description: Een API om een zaaktypecataloguscomponent te benaderen
-  version: 1.0.0
+  title: Zaaktypecatalogus (ZTC) API documentatie
+  description: >-
+    Introductie
+
+    -----------
+
+
+    De GEMMA Zaaktypecatalogus 2 (ZTC2, ofwel de 2e generatie zaaktypecatalogus)
+
+    helpt gemeenten om het proces vanuit de 'vraag van een klant'
+    (productaanvraag,
+
+    melding, aangifte, informatieverzoek e.d.) tot en met het leveren van een
+
+    passend antwoord daarop in te richten, inclusief de bijbehorende
+
+    informatievoorziening. Opslag van gegevens gebeurt conform het
+
+    [Informatiemodel Zaaktypen/Zaaktypecatalogus][1] (ImZTC, versie 2.1).
+
+
+    De catalogi worden middels een RESTful API ontsloten. Hierbij is zeer sterk
+
+    gekeken naar het [Digitaal Stelsel Omgevingswet][2] (DSO) voor de API- en
+    URI
+
+    strategie, en [StUF-ZTC][3] om zo goed mogelijk aan te sluiten op de
+    services
+
+    zoals deze zijn gedefinieerd in SOAP.
+
+
+    [1]: http://www.gemmaonline.nl/index.php/Informatiemodel_Zaaktypen_(ImZTC)
+
+    [2]:
+    https://aandeslagmetdeomgevingswet.nl/digitaal-stelsel/documenten/documenten/api-uri-strategie/
+
+    [3]:
+    https://www.gemmaonline.nl/index.php/Sectormodel_Zaaktypen(-catalogus):_StUF%E2%80%93ZTC
+
+
+
+    Waarschuwing
+
+    ------------
+
+
+    Hoewel op dit moment versie 1 van de API beschikbaar is, kunnen er breaking
+
+    changes voorkomen zolang de Zaaktypecatalogus nog niet versie 1.0.0 heeft
+
+    bereikt.
   contact:
-    url:  https://github.com/VNG-Realisatie/gemma-zaken
+    url: 'https://github.com/VNG-Realisatie/gemma-zaken'
+    email: support@maykinmedia.nl
+  license:
+    name: EUPL 1.2
+  version: '1'
+security:
+  - OAuth2: []
+    Bearer: []
 paths:
-  'api/v{version}/zaaktypes/{zaaktype-id}':
+  /catalogussen:
     get:
-      summary: Ophalen van een zaaktype via het id
-      operationId: ophalenZaaktype
-      parameters:
-        - name: zaaktype-id
-          in: path
-          required: true
-          schema:
-            type: string
+      operationId: catalogus_list
+      description: Een verzameling van CATALOGUSsen.
       responses:
-        200:
-          description: Zaaktype
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Zaaktype'
-        default:
-          description: Onverwachte fout
+                type: array
+                items:
+                  $ref: '#/components/schemas/Catalogus'
+      tags:
+        - catalogussen
+    parameters: []
+  '/catalogussen/{catalogus_pk}/zaaktypen':
+    get:
+      operationId: zaaktype_list
+      description: Een verzameling van ZAAKTYPEn.
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Fout'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakType'
+      tags:
+        - catalogussen
     parameters:
-      - name: version
+      - name: catalogus_pk
         in: path
         required: true
         schema:
           type: string
-  'api/v{version}/zaaktypes/{zaaktype-id}/statussen/{status-id}':
+  '/catalogussen/{catalogus_pk}/zaaktypen/{id}':
     get:
-      summary: Ophalen van een zaak status via het zaaktype id en status id
-      operationId: ophalenZaakstatus
-      parameters:
-        - name: zaaktype-id
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: status-id
-          in: path
-          required: true
-          schema:
-            type: string
+      operationId: zaaktype_read
+      description: >-
+        Het geheel van karakteristieke eigenschappen van zaken van eenzelfde
+        soort.
       responses:
-        200:
-          description: Zaak status
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Zaakstatus'
-        default:
-          description: Onverwachte fout
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fout'
+                $ref: '#/components/schemas/ZaakType'
+      tags:
+        - catalogussen
     parameters:
-      - name: version
+      - name: catalogus_pk
         in: path
         required: true
         schema:
           type: string
+      - name: id
+        in: path
+        description: A unique integer value identifying this Zaaktype.
+        required: true
+        schema:
+          type: integer
+  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/statustypen':
+    get:
+      operationId: statustype_list
+      description: Een verzameling van STATUSTYPEn.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StatusType'
+      tags:
+        - catalogussen
+    parameters:
+      - name: zaaktype_pk
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: catalogus_pk
+        in: path
+        required: true
+        schema:
+          type: string
+  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/statustypen/{id}':
+    get:
+      operationId: statustype_read
+      description: Generieke aanduiding van de aard van een status.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusType'
+      tags:
+        - catalogussen
+    parameters:
+      - name: zaaktype_pk
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: catalogus_pk
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: A unique integer value identifying this Statustype.
+        required: true
+        schema:
+          type: integer
+  '/catalogussen/{id}':
+    get:
+      operationId: catalogus_read
+      description: >-
+        De verzameling van ZAAKTYPEn - incl. daarvoor relevante objecttypen -
+        voor een Domein die als één geheel beheerd
+
+        wordt.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalogus'
+      tags:
+        - catalogussen
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this catalogus.
+        required: true
+        schema:
+          type: integer
 servers:
-  - url: /
+  - url: /api/v1
 components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: /oauth2/token/
+          scopes:
+            write: Schrijftoegang tot de catalogus en gerelateerde objecten.
+            read: Leestoegang tot de catalogus en gerelateerde objecten.
+    Bearer:
+      type: apiKey
+      name: Authorization
+      in: header
   schemas:
-    Zaaktype:
-      description: Een zaaktype
+    Catalogus:
+      required:
+        - domein
+        - rsin
+        - contactpersoonBeheerNaam
+      type: object
       properties:
-        id:
-          description: ID van het zaaktype
+        url:
+          title: Url
           type: string
-        naam:
-          description: Naam van het zaaktype
+          format: uri
+          readOnly: true
+        domein:
+          title: Domein
+          description: >-
+            Een afkorting waarmee wordt aangegeven voor welk domein in een
+            CATALOGUS ZAAKTYPEn zijn uitgewerkt.
           type: string
-        omschrijving:
-          description: Omschrijving van het zaaktype
+          maxLength: 5
+        rsin:
+          title: Rsin
+          description: >-
+            Het door een kamer toegekend uniek nummer voor de INGESCHREVEN
+            NIET-NATUURLIJK PERSOON die de eigenaar is van een CATALOGUS.
           type: string
-        statussen:
-          description: Lijst met URL's van alle mogelijke statussen behorende bij het zaaktype
+          maxLength: 9
+        contactpersoonBeheerNaam:
+          title: Naam
+          description: >-
+            De naam van de contactpersoon die verantwoordelijk is voor het
+            beheer van de CATALOGUS.
+          type: string
+          maxLength: 40
+        contactpersoonBeheerTelefoonnummer:
+          title: Telefoonnummer
+          description: >-
+            Het telefoonnummer van de contactpersoon die verantwoordelijk is
+            voor het beheer van de CATALOGUS.
+          type: string
+          maxLength: 20
+        contactpersoonBeheerEmailadres:
+          title: Emailadres
+          description: >-
+            Het emailadres van de contactpersoon die verantwoordelijk is voor
+            het beheer van de CATALOGUS.
+          type: string
+          format: email
+          maxLength: 254
+        zaaktypen:
+          title: Zaaktypen
           type: array
           items:
             type: string
-    Zaakstatus:
-      description: Status van een zaak
+            format: uri
+          readOnly: true
+          uniqueItems: true
+    ZaakType:
+      required:
+        - identificatie
+        - omschrijving
+        - maaktDeelUitVan
+      type: object
       properties:
-        id:
-          description: ID naar de status
+        url:
+          title: Url
           type: string
-        naam:
-          description: Naam van de status
-          type: string
+          format: uri
+          readOnly: true
+        identificatie:
+          title: Identificatie
+          description: >-
+            Unieke identificatie van het ZAAKTYPE binnen de CATALOGUS waarin het
+            ZAAKTYPE voorkomt.
+          type: integer
+          maximum: 99999
+          minimum: 0
         omschrijving:
-          description: Omschrijving van de status
+          title: Omschrijving
+          description: Omschrijving van de aard van ZAAKen van het ZAAKTYPE.
           type: string
-    Fout:
-      description: Een opgetreden fout
+          maxLength: 80
+        omschrijvingGeneriek:
+          title: Omschrijving generiek
+          description: >-
+            Algemeen gehanteerde omschrijving van de aard van ZAAKen van het
+            ZAAKTYPE
+          type: string
+          maxLength: 80
+        maaktDeelUitVan:
+          title: Maakt deel uit van
+          description: De CATALOGUS waartoe dit ZAAKTYPE behoort.
+          type: string
+          format: uri
+        statustypen:
+          title: Statustypen
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
+    StatusType:
+      required:
+        - omschrijving
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        omschrijving:
+          title: Omschrijving
+          description: >-
+            Een korte, voor de initiator van de zaak relevante, omschrijving van
+            de aard van de STATUS van zaken van een ZAAKTYPE.
+          type: string
+          maxLength: 80
+        omschrijvingGeneriek:
+          title: Omschrijving generiek
+          description: >-
+            Algemeen gehanteerde omschrijving van de aard van STATUSsen van het
+            STATUSTYPE
+          type: string
+          maxLength: 80
+        statustekst:
+          title: Statustekst
+          description: >-
+            De tekst die wordt gebruikt om de Initiator te informeren over het
+            bereiken van een STATUS van dit STATUSTYPE bij het desbetreffende
+            ZAAKTYPE.
+          type: string
+          maxLength: 1000
+        isVan:
+          title: Is van
+          type: string
+          format: uri
+          readOnly: true


### PR DESCRIPTION
**Browsable spec**

* [ZRC](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/c8d4b22a3b4558c528a62ecd3c65ce9d690c09f0/api-specificatie/zrc/openapi.yaml)
* [DRC](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/c8d4b22a3b4558c528a62ecd3c65ce9d690c09f0/api-specificatie/drc/openapi.yaml)
* [ZTC](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/c8d4b22a3b4558c528a62ecd3c65ce9d690c09f0/api-specificatie/ztc/openapi.yaml)

**Referentieimplementatie**
Zie:
* https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/blob/develop/src/openapi.yaml 
* https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/blob/develop/src/openapi.yaml
* https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/blob/develop/src/openapi.yaml
voor de referentie-implementatie hierachter.

**Status**
Specuitbreiding voor #39 zodat de volgende datavelden meegenomen kunnen worden:

- [x] `id`
- [x] `last_status`
  - [x] ZRC aspect
  - [x] ZTC aspect
- [x] `adres`
- [x] `datetime`
- [x] `text`
- [x] Domein data
  - [x] `waternet_soort_boot`
  - [x] `waternet_rederij`
  - [x] `waternet_naam_boot`
  - [x] ORC aspect
- [x] `datetime_overlast`
- [x] `source`
- [x] `text_extra` -> kan in domeindata
- [x] `image`
  - [x] ZRC aspect
  - [x] DRC aspect
- [x] Zaaktype
  - [x] `main_category`
  - [x] `sub_category`
  - [x] `ml_cat`
- [x] `stadsdeel`
- [x] `coordinates`
- [x] `verantwoordelijk`
