### PR TITLE
Feature/us 52 zaakeigenschappen en geo

### DIFF
--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -1,12 +1,13 @@
 openapi: 3.0.0
 info:
-  title: Zaak registratie API
-  description: Een API om een zaakregistratiecomponent te kunnen benaderen
+  title: Zaakregistratiecomponent (ZRC) API
+  description: Een API om een zaakregistratiecomponent te benaderen
   contact:
-    url:  https://github.com/VNG-Realisatie/gemma-zaken
+    url: 'https://github.com/VNG-Realisatie/gemma-zaken'
+    email: support@maykinmedia.nl
   license:
     name: EUPL 1.2
-  version: 1.0.0
+  version: '1'
 security:
   - basic: []
 paths:
@@ -27,46 +28,6 @@ paths:
       - name: id
         in: path
         description: A unique integer value identifying this Organisatorische eenheid.
-        required: true
-        schema:
-          type: integer
-  /domeindata:
-    post:
-      operationId: domeindata_create
-      description: Registreer DOMEINDATA bij een zaak.
-      responses:
-        '201':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DomeinData'
-      tags:
-        - domeindata
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DomeinData'
-        required: true
-    parameters: []
-  '/domeindata/{id}':
-    get:
-      operationId: domeindata_read
-      description: Geef de details van DOMEINDATA voor een ZAAK.
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DomeinData'
-      tags:
-        - domeindata
-    parameters:
-      - name: id
-        in: path
-        description: A unique integer value identifying this domeindatareferentie.
         required: true
         schema:
           type: integer
@@ -237,7 +198,6 @@ paths:
           type: integer
   /zaken:
     post:
-      summary: Aanmaken nieuwe zaak
       operationId: zaak_create
       description: >-
         Maak een ZAAK aan.
@@ -247,23 +207,11 @@ paths:
         gegenereerd.
       responses:
         '201':
-          description: "Representatie van aangemaakte ZAAK"
+          description: ''
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Zaak'
-        '422':
-          description: Opgegeven zaak informatie kan niet verwerkt worden
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        default:
-          description: Onverwachte fout tijdens opvoeren zaak
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Fout'
       tags:
         - zaken
       requestBody:
@@ -293,6 +241,70 @@ paths:
         required: true
         schema:
           type: integer
+  '/zaken/{zaak_pk}/zaakeigenschappen':
+    get:
+      operationId: zaakeigenschap_list
+      description: Geef een collectie van eigenschappen behorend bij een ZAAK.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakEigenschap'
+      tags:
+        - zaken
+    post:
+      operationId: zaakeigenschap_create
+      description: Registreer een eigenschap van een ZAAK.
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakEigenschap'
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakEigenschap'
+        required: true
+    parameters:
+      - name: zaak_pk
+        in: path
+        required: true
+        schema:
+          type: string
+  '/zaken/{zaak_pk}/zaakeigenschappen/{id}':
+    get:
+      operationId: zaakeigenschap_read
+      description: Geef de details van ZaakEigenschap voor een ZAAK.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakEigenschap'
+      tags:
+        - zaken
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this zaakeigenschap.
+        required: true
+        schema:
+          type: integer
+      - name: zaak_pk
+        in: path
+        required: true
+        schema:
+          type: string
 servers:
   - url: /api/v1
 components:
@@ -338,28 +350,6 @@ components:
           description: De feitelijke naam van de organisatorische eenheid.
           type: string
           maxLength: 50
-          minLength: 1
-    DomeinData:
-      required:
-        - zaak
-        - domeinData
-      type: object
-      properties:
-        url:
-          title: Url
-          type: string
-          format: uri
-          readOnly: true
-        zaak:
-          title: Zaak
-          type: string
-          format: uri
-        domeinData:
-          title: Domein data
-          description: URL naar de domein data resource
-          type: string
-          format: uri
-          maxLength: 200
           minLength: 1
     KlantContact:
       required:
@@ -506,7 +496,6 @@ components:
           type: string
           maxLength: 80
     Zaak:
-      description: Een ZAAK
       required:
         - zaaktype
         - registratiedatum
@@ -543,46 +532,40 @@ components:
           description: Een toelichting op de zaak.
           type: string
           maxLength: 1000
-        omschrijving:
-          title: Omschrijving
-          description: Een korte omschrijving van de zaak.
-          type: string
-          maxLength: 80
         zaakgeometrie:
           title: Zaakgeometrie
           description: 'Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON.'
           type: object
-        objecten:
-          title: OBJECTen
-          description: Lijst met URL's naar aan de zaak gerelateerde objecten
-          type: array
-          items:
-            type: string
         status:
           title: Status
           description: 'Indien geen status bekend is, dan is de waarde ''null'''
           type: string
           format: uri
           readOnly: true
-    Fout:
-      description: Een opgetreden fout
+    ZaakEigenschap:
+      required:
+        - zaak
+        - eigenschap
+        - waarde
+      type: object
       properties:
-        title:
-          description: Wat er is misgegaan
+        url:
+          title: Url
           type: string
-        status:
-          description: HTTP Response code
-          type: integer
-        detail:
-          description: Meer details over de fout
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
           type: string
-        invalid-params:
-          description: Lijst met fouten in invoer parameters
-          type: object
-          properties:
-            name:
-              description: Naam van de parameter met invalide inhoud
-              type: string
-            reason:
-              description: Wat er mis is met de inhoud van de parameter
-              type: string
+          format: uri
+        eigenschap:
+          title: Eigenschap
+          description: URL naar de eigenschap in het ZTC
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
+        waarde:
+          title: Waarde
+          type: string
+          minLength: 1

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -126,6 +126,66 @@ paths:
         required: true
         schema:
           type: integer
+  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/eigenschappen':
+    get:
+      operationId: eigenschap_list
+      description: Een verzameling van EIGENSCHAPpen.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Eigenschap'
+      tags:
+        - catalogussen
+    parameters:
+      - name: zaaktype_pk
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: catalogus_pk
+        in: path
+        required: true
+        schema:
+          type: string
+  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/eigenschappen/{id}':
+    get:
+      operationId: eigenschap_read
+      description: >-
+        Een relevant inhoudelijk gegeven dat bij ZAAKen van dit ZAAKTYPE
+        geregistreerd moet kunnen worden en geen standaard
+
+        kenmerk is van een zaak.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Eigenschap'
+      tags:
+        - catalogussen
+    parameters:
+      - name: zaaktype_pk
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: catalogus_pk
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: A unique integer value identifying this Eigenschap.
+        required: true
+        schema:
+          type: integer
   '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/statustypen':
     get:
       operationId: statustype_list
@@ -324,6 +384,111 @@ components:
             format: uri
           readOnly: true
           uniqueItems: true
+        eigenschappen:
+          title: Eigenschappen
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
+    EigenschapSpecificatie:
+      title: Specificatie
+      required:
+        - formaat
+        - lengte
+        - kardinaliteit
+      type: object
+      properties:
+        groep:
+          title: Groep
+          description: >-
+            Benaming van het object of groepattribuut waarvan de EIGENSCHAP een
+            inhoudelijk gegeven specificeert.
+          type: string
+          maxLength: 32
+        formaat:
+          title: Formaat
+          description: >-
+            Het soort tekens waarmee waarden van de EIGENSCHAP kunnen worden
+            vastgelegd.
+          type: string
+          enum:
+            - tekst
+            - getal
+            - datum (jjjjmmdd)
+            - datum/tijd (jjjjmmdduummss)
+        lengte:
+          title: Lengte
+          description: >-
+            Het aantal karakters (lengte) waarmee waarden van de EIGENSCHAP
+            worden vastgelegd.
+          type: string
+          maxLength: 14
+        kardinaliteit:
+          title: Kardinaliteit
+          description: >-
+            Het aantal mogelijke voorkomens van waarden van deze EIGENSCHAP bij
+            een zaak van het ZAAKTYPE.
+          type: string
+          maxLength: 3
+        waardenverzameling:
+          title: Waardenverzameling
+          description: >-
+            Waarden die deze EIGENSCHAP kan hebben (Gebruik een komma om waarden
+            van elkaar te onderscheiden.)
+          type: array
+          items:
+            title: Waardenverzameling
+            type: string
+            maxLength: 100
+      readOnly: true
+    Eigenschap:
+      required:
+        - naam
+        - definitie
+        - ingangsdatumObject
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        naam:
+          title: Naam
+          description: De naam van de EIGENSCHAP
+          type: string
+          maxLength: 20
+        definitie:
+          title: Definitie
+          description: De beschrijving van de betekenis van deze EIGENSCHAP
+          type: string
+          maxLength: 255
+        specificatie:
+          $ref: '#/components/schemas/EigenschapSpecificatie'
+        toelichting:
+          title: Toelichting
+          description: >-
+            Een toelichting op deze EIGENSCHAP en het belang hiervan voor zaken
+            van dit ZAAKTYPE.
+          type: string
+          maxLength: 1000
+        ingangsdatumObject:
+          title: Ingangsdatum object
+          description: De datum waarop het is ontstaan.
+          type: string
+          format: date
+        einddatumObject:
+          title: Einddatum object
+          description: De datum waarop het is opgeheven.
+          type: string
+          format: date
+        zaaktype:
+          title: Zaaktype
+          type: string
+          format: uri
+          readOnly: true
     StatusType:
       required:
         - omschrijving


### PR DESCRIPTION
De wijzigingen hier zijn in het ZTC en ZRC.

**ZTC**

Onder een zaaktype kan je `EIGENSCHAP`pen specifieren. De API uitbreiding laat hier toe om die configuratie op te vragen als een collectie behorend bij een zaaktype.

Op deze manier kunnen clients de namen en datatypes/kardinaliteit e.d. van zaaktype-specifieke zaakeigenschappen uitlezen. Concreet voor Amsterdam betekent dit dat een eigenschap kan gedefinieerd worden met de naam `objecttype`, en de mogelijke waardes (`overlast_water`, `lantaarnpaal` etc.). Clients weten dan welke namen van eigenschappen ze moeten kunnen behandelen. Een 'zwerfvuil' behandelaar bijv. kan op deze manier zien dat ze de groep eigenschappen met naam 'zwerfvuil' uitlezen om de eigenschappen bij de zaak te kunnen tonen.

**ZRC**

Nadat de client weet wat de URLs zijn van de relevante eigenschappen, kan het `ZAAKEIGENSCHAP`pen collectie als resource opgevraagd worden bij de zaak. Deze data hoort bij 1 enkele zaak, en is daarom dus als nested resource ontsloten. Op basis van de `eigenschap` url kunnen de `key: value` pairs die relevant zijn voor de betreffende client (lees: behandelaar) getoond worden en/of gebruikt worden voor verdere verwerking.

**Overige opmerkingen**

Deze aanpak legt het formaat van de 'arbitraire' data vast in de zaaktypecatalogus, waarover de gemeente controle heeft. Dit voorkomt een wildgroei aan custom formaten bij leveranciers.

