### PR TITLE
Voeg bronorganisatie toe aan Zaak-resource

### DIFF
--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -497,6 +497,7 @@ components:
           maxLength: 80
     Zaak:
       required:
+        - bronorganisatie
         - zaaktype
         - registratiedatum
       type: object
@@ -513,6 +514,14 @@ components:
             verantwoordelijk is voor de behandeling van de ZAAK.
           type: string
           maxLength: 40
+        bronorganisatie:
+          title: Bronorganisatie
+          description: >-
+            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die de
+            zaak heeft gecreeerd.
+          type: string
+          maxLength: 9
+          minLength: 1
         zaaktype:
           title: Zaaktype
           description: URL naar het zaaktype in de CATALOGUS waar deze voorkomt


### PR DESCRIPTION
Gerelateerd aan #208: bronorganisatie + zaakidentificatie samen
identificeren een zaak eenduidig. Bronorganisatie moet dus minstens
mee ontsloten worden.