### PR TITLE
Feature/uuids

### DIFF
--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -31,7 +31,7 @@ paths:
               $ref: '#/components/schemas/EnkelvoudigInformatieObject'
         required: true
     parameters: []
-  '/enkelvoudiginformatieobjecten/{id}':
+  '/enkelvoudiginformatieobjecten/{uuid}':
     get:
       operationId: enkelvoudiginformatieobject_read
       description: Geef de details van een EnkelvoudigInformatieObject.
@@ -45,12 +45,13 @@ paths:
       tags:
         - enkelvoudiginformatieobjecten
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this informatieobject.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
   /zaakinformatieobjecten:
     post:
       operationId: zaakinformatieobject_create
@@ -71,7 +72,7 @@ paths:
               $ref: '#/components/schemas/ZaakInformatieObject'
         required: true
     parameters: []
-  '/zaakinformatieobjecten/{id}':
+  '/zaakinformatieobjecten/{uuid}':
     get:
       operationId: zaakinformatieobject_read
       description: Geef de details van een ZAAKINFORMATIEOBJECT relatie.
@@ -85,12 +86,13 @@ paths:
       tags:
         - zaakinformatieobjecten
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this Zaakinformatieobject.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
 servers:
   - url: /api/v1
 components:

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -11,7 +11,7 @@ info:
 security:
   - basic: []
 paths:
-  '/betrokkenen/{id}':
+  '/betrokkenen/{uuid}':
     get:
       operationId: organisatorischeeenheid_read
       description: ''
@@ -25,18 +25,32 @@ paths:
       tags:
         - betrokkenen
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this Organisatorische eenheid.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
   /klantcontacten:
+    get:
+      operationId: klantcontact_list
+      description: Geef een lijst van KLANTCONTACTen.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/KlantContact'
+      tags:
+        - klantcontacten
     post:
       operationId: klantcontact_create
-      description: >-
+      description: |-
         Registreer een klantcontact bij een ZAAK.
-
 
         Indien geen identificatie gegeven is, dan wordt deze automatisch
         gegenereerd.
@@ -56,10 +70,10 @@ paths:
               $ref: '#/components/schemas/KlantContact'
         required: true
     parameters: []
-  '/klantcontacten/{id}':
+  '/klantcontacten/{uuid}':
     get:
       operationId: klantcontact_read
-      description: Geef de details van een klantcontact voor een ZAAK.
+      description: Opvragen en bewerken van KLANTCONTACTen.
       responses:
         '200':
           description: ''
@@ -70,13 +84,28 @@ paths:
       tags:
         - klantcontacten
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this klantcontact.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
   /rollen:
+    get:
+      operationId: rol_list
+      description: Opvragen en bewerken van ROLrelatie tussen een ZAAK en een BETROKKENE.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Rol'
+      tags:
+        - rollen
     post:
       operationId: rol_create
       description: Koppel een BETROKKENE aan een ZAAK.
@@ -96,10 +125,10 @@ paths:
               $ref: '#/components/schemas/Rol'
         required: true
     parameters: []
-  '/rollen/{id}':
+  '/rollen/{uuid}':
     get:
       operationId: rol_read
-      description: ''
+      description: Opvragen en bewerken van ROLrelatie tussen een ZAAK en een BETROKKENE.
       responses:
         '200':
           description: ''
@@ -110,13 +139,28 @@ paths:
       tags:
         - rollen
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this Rol.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
   /statussen:
+    get:
+      operationId: status_list
+      description: ''
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Status'
+      tags:
+        - statussen
     post:
       operationId: status_create
       description: ''
@@ -136,7 +180,7 @@ paths:
               $ref: '#/components/schemas/Status'
         required: true
     parameters: []
-  '/statussen/{id}':
+  '/statussen/{uuid}':
     get:
       operationId: status_read
       description: ''
@@ -150,13 +194,28 @@ paths:
       tags:
         - statussen
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this status.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
   /zaakobjecten:
+    get:
+      operationId: zaakobject_list
+      description: Geef een lijst van ZAAKOBJECTrelaties terug.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakObject'
+      tags:
+        - zaakobjecten
     post:
       operationId: zaakobject_create
       description: Registreer een ZAAKOBJECT relatie.
@@ -176,7 +235,7 @@ paths:
               $ref: '#/components/schemas/ZaakObject'
         required: true
     parameters: []
-  '/zaakobjecten/{id}':
+  '/zaakobjecten/{uuid}':
     get:
       operationId: zaakobject_read
       description: Geef de details van een ZAAKOBJECT relatie.
@@ -190,13 +249,68 @@ paths:
       tags:
         - zaakobjecten
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this zaakobject.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
   /zaken:
+    get:
+      operationId: zaak_list
+      description: Geef een lijst van ZAAKen.
+      parameters:
+        - name: zaakidentificatie
+          in: query
+          description: ''
+          required: false
+          schema:
+            type: string
+        - name: bronorganisatie
+          in: query
+          description: ''
+          required: false
+          schema:
+            type: string
+        - name: zaaktype
+          in: query
+          description: ''
+          required: false
+          schema:
+            type: string
+        - name: Accept-Crs
+          in: header
+          description: >-
+            Het 'Coordinate Reference System' (CRS) van de verzoekdata. Volgens
+            de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als
+            WGS84).
+          required: true
+          schema:
+            type: string
+            enum:
+              - 'EPSG:4326'
+      responses:
+        '200':
+          description: ''
+          headers:
+            Content-Crs:
+              description: >-
+                Het 'Coordinate Reference System' (CRS) van de antwoorddata.
+                Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is
+                hetzelfde als WGS84).
+              schema:
+                type: string
+                enum:
+                  - 'EPSG:4326'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Zaak'
+      tags:
+        - zaken
     post:
       operationId: zaak_create
       description: |-
@@ -276,7 +390,7 @@ paths:
               $ref: '#/components/schemas/ZaakZoek'
         required: true
     parameters: []
-  '/zaken/{id}':
+  '/zaken/{uuid}':
     get:
       operationId: zaak_read
       description: Opvragen en bewerken van ZAAKen.
@@ -312,13 +426,14 @@ paths:
       tags:
         - zaken
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this zaak.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
-  '/zaken/{zaak_pk}/zaakeigenschappen':
+          type: string
+          format: uuid
+  '/zaken/{zaak_uuid}/zaakeigenschappen':
     get:
       operationId: zaakeigenschap_list
       description: Geef een collectie van eigenschappen behorend bij een ZAAK.
@@ -352,12 +467,14 @@ paths:
               $ref: '#/components/schemas/ZaakEigenschap'
         required: true
     parameters:
-      - name: zaak_pk
+      - name: zaak_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-  '/zaken/{zaak_pk}/zaakeigenschappen/{id}':
+          format: uuid
+  '/zaken/{zaak_uuid}/zaakeigenschappen/{uuid}':
     get:
       operationId: zaakeigenschap_read
       description: Geef de details van ZaakEigenschap voor een ZAAK.
@@ -371,17 +488,20 @@ paths:
       tags:
         - zaken
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this zaakeigenschap.
-        required: true
-        schema:
-          type: integer
-      - name: zaak_pk
-        in: path
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
           type: string
+          format: uuid
+      - name: zaak_uuid
+        in: path
+        required: true
+        description: Unieke resource identifier (UUID4)
+        schema:
+          type: string
+          format: uuid
 servers:
   - url: /api/v1
 components:

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -59,8 +59,8 @@ info:
     name: EUPL 1.2
   version: '1'
 security:
+  - Bearer: []
   - OAuth2: []
-    Bearer: []
 paths:
   /catalogussen:
     get:
@@ -294,6 +294,10 @@ servers:
   - url: /api/v1
 components:
   securitySchemes:
+    Bearer:
+      in: header
+      name: Authorization
+      type: apiKey
     OAuth2:
       type: oauth2
       flows:
@@ -302,10 +306,6 @@ components:
           scopes:
             write: Schrijftoegang tot de catalogus en gerelateerde objecten.
             read: Leestoegang tot de catalogus en gerelateerde objecten.
-    Bearer:
-      type: apiKey
-      name: Authorization
-      in: header
   schemas:
     Catalogus:
       required:
@@ -326,6 +326,7 @@ components:
             CATALOGUS ZAAKTYPEn zijn uitgewerkt.
           type: string
           maxLength: 5
+          minLength: 1
         rsin:
           title: Rsin
           description: >-
@@ -333,6 +334,7 @@ components:
             NIET-NATUURLIJK PERSOON die de eigenaar is van een CATALOGUS.
           type: string
           maxLength: 9
+          minLength: 1
         contactpersoonBeheerNaam:
           title: Naam
           description: >-
@@ -340,6 +342,7 @@ components:
             beheer van de CATALOGUS.
           type: string
           maxLength: 40
+          minLength: 1
         contactpersoonBeheerTelefoonnummer:
           title: Telefoonnummer
           description: >-
@@ -356,7 +359,6 @@ components:
           format: email
           maxLength: 254
         zaaktypen:
-          title: Zaaktypen
           type: array
           items:
             type: string
@@ -388,6 +390,7 @@ components:
           description: Omschrijving van de aard van ZAAKen van het ZAAKTYPE.
           type: string
           maxLength: 80
+          minLength: 1
         omschrijvingGeneriek:
           title: Omschrijving generiek
           description: >-
@@ -401,7 +404,6 @@ components:
           type: string
           format: uri
         statustypen:
-          title: Statustypen
           type: array
           items:
             type: string
@@ -409,7 +411,6 @@ components:
           readOnly: true
           uniqueItems: true
         eigenschappen:
-          title: Eigenschappen
           type: array
           items:
             type: string
@@ -449,6 +450,7 @@ components:
             worden vastgelegd.
           type: string
           maxLength: 14
+          minLength: 1
         kardinaliteit:
           title: Kardinaliteit
           description: >-
@@ -456,8 +458,8 @@ components:
             een zaak van het ZAAKTYPE.
           type: string
           maxLength: 3
+          minLength: 1
         waardenverzameling:
-          title: Waardenverzameling
           description: >-
             Waarden die deze EIGENSCHAP kan hebben (Gebruik een komma om waarden
             van elkaar te onderscheiden.)
@@ -466,6 +468,7 @@ components:
             title: Waardenverzameling
             type: string
             maxLength: 100
+            minLength: 1
       readOnly: true
     Eigenschap:
       required:
@@ -484,11 +487,13 @@ components:
           description: De naam van de EIGENSCHAP
           type: string
           maxLength: 20
+          minLength: 1
         definitie:
           title: Definitie
           description: De beschrijving van de betekenis van deze EIGENSCHAP
           type: string
           maxLength: 255
+          minLength: 1
         specificatie:
           $ref: '#/components/schemas/EigenschapSpecificatie'
         toelichting:
@@ -530,6 +535,7 @@ components:
             de aard van de STATUS van zaken van een ZAAKTYPE.
           type: string
           maxLength: 80
+          minLength: 1
         omschrijvingGeneriek:
           title: Omschrijving generiek
           description: >-

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -78,7 +78,7 @@ paths:
       tags:
         - catalogussen
     parameters: []
-  '/catalogussen/{catalogus_pk}/zaaktypen':
+  '/catalogussen/{catalogus_uuid}/zaaktypen':
     get:
       operationId: zaaktype_list
       description: Een verzameling van ZAAKTYPEn.
@@ -94,12 +94,14 @@ paths:
       tags:
         - catalogussen
     parameters:
-      - name: catalogus_pk
+      - name: catalogus_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-  '/catalogussen/{catalogus_pk}/zaaktypen/{id}':
+          format: uuid
+  '/catalogussen/{catalogus_uuid}/zaaktypen/{uuid}':
     get:
       operationId: zaaktype_read
       description: >-
@@ -115,18 +117,21 @@ paths:
       tags:
         - catalogussen
     parameters:
-      - name: catalogus_pk
+      - name: catalogus_uuid
         in: path
+        required: true
+        description: Unieke resource identifier (UUID4)
+        schema:
+          type: string
+          format: uuid
+      - name: uuid
+        in: path
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
           type: string
-      - name: id
-        in: path
-        description: A unique integer value identifying this Zaaktype.
-        required: true
-        schema:
-          type: integer
-  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/eigenschappen':
+          format: uuid
+  '/catalogussen/{catalogus_uuid}/zaaktypen/{zaaktype_uuid}/eigenschappen':
     get:
       operationId: eigenschap_list
       description: Een verzameling van EIGENSCHAPpen.
@@ -142,17 +147,21 @@ paths:
       tags:
         - catalogussen
     parameters:
-      - name: zaaktype_pk
+      - name: catalogus_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-      - name: catalogus_pk
+          format: uuid
+      - name: zaaktype_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/eigenschappen/{id}':
+          format: uuid
+  '/catalogussen/{catalogus_uuid}/zaaktypen/{zaaktype_uuid}/eigenschappen/{uuid}':
     get:
       operationId: eigenschap_read
       description: >-
@@ -170,23 +179,28 @@ paths:
       tags:
         - catalogussen
     parameters:
-      - name: zaaktype_pk
+      - name: catalogus_uuid
         in: path
+        required: true
+        description: Unieke resource identifier (UUID4)
+        schema:
+          type: string
+          format: uuid
+      - name: uuid
+        in: path
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
           type: string
-      - name: catalogus_pk
+          format: uuid
+      - name: zaaktype_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-      - name: id
-        in: path
-        description: A unique integer value identifying this Eigenschap.
-        required: true
-        schema:
-          type: integer
-  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/statustypen':
+          format: uuid
+  '/catalogussen/{catalogus_uuid}/zaaktypen/{zaaktype_uuid}/statustypen':
     get:
       operationId: statustype_list
       description: Een verzameling van STATUSTYPEn.
@@ -202,17 +216,21 @@ paths:
       tags:
         - catalogussen
     parameters:
-      - name: zaaktype_pk
+      - name: catalogus_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-      - name: catalogus_pk
+          format: uuid
+      - name: zaaktype_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-  '/catalogussen/{catalogus_pk}/zaaktypen/{zaaktype_pk}/statustypen/{id}':
+          format: uuid
+  '/catalogussen/{catalogus_uuid}/zaaktypen/{zaaktype_uuid}/statustypen/{uuid}':
     get:
       operationId: statustype_read
       description: Generieke aanduiding van de aard van een status.
@@ -226,23 +244,28 @@ paths:
       tags:
         - catalogussen
     parameters:
-      - name: zaaktype_pk
+      - name: catalogus_uuid
         in: path
+        required: true
+        description: Unieke resource identifier (UUID4)
+        schema:
+          type: string
+          format: uuid
+      - name: uuid
+        in: path
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
           type: string
-      - name: catalogus_pk
+          format: uuid
+      - name: zaaktype_uuid
         in: path
         required: true
+        description: Unieke resource identifier (UUID4)
         schema:
           type: string
-      - name: id
-        in: path
-        description: A unique integer value identifying this Statustype.
-        required: true
-        schema:
-          type: integer
-  '/catalogussen/{id}':
+          format: uuid
+  '/catalogussen/{uuid}':
     get:
       operationId: catalogus_read
       description: >-
@@ -260,12 +283,13 @@ paths:
       tags:
         - catalogussen
     parameters:
-      - name: id
+      - name: uuid
         in: path
-        description: A unique integer value identifying this catalogus.
+        description: Unieke resource identifier (UUID4)
         required: true
         schema:
-          type: integer
+          type: string
+          format: uuid
 servers:
   - url: /api/v1
 components:


### PR DESCRIPTION
In de [designkeuzes](https://github.com/VNG-Realisatie/gemma-zaken/blob/master/docs/content/design-keuzes.md) is beschreven waarom voor UUID gekozen is.

**Referentieimplementaties**
Pull requests bij de referentie-implementaties:

* [ZRC](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/7)
* [DRC](https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/pull/11)
* [ZTC](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/4)

**API specs**

* [ZRC](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/uuids/api-specificatie/zrc/openapi.yaml)
* [DRC](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/uuids/api-specificatie/drc/openapi.yaml)
* [ZTC](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/uuids/api-specificatie/ztc/openapi.yaml)