### PR TITLE
zrc openapi.yaml Schema error

### DIFF
--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -695,7 +695,8 @@ components:
     Geometry:
       title: Geometry
       description: GeoJSON geometry
-      required: type
+      required: 
+        - type
       type: object
       properties:
         type:


### PR DESCRIPTION
zrc/openapi.yaml Schema error at components.schemas['Geometry'] impediment #240
https://github.com/VNG-Realisatie/gemma-zaken/issues/240