### PR TITLE
Aanpassingen op de README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Een gehoste versie van de documentatie is beschikbaar op https://ref.tst.vng.clo
 
 ## API spec bekijken
 
-Zie de relevante links in dit [overzicht](./docs/content/developers/api-specifications.md).
+Zie de relevante links in dit [overzicht](./docs/content/developers/api-specificaties.md).
 
 ## Licentie
 Copyright © VNG Realisatie 2018

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Een gehoste versie van de documentatie is beschikbaar op https://ref.tst.vng.clo
 
 Zie de relevante links in dit [overzicht](./docs/content/developers/api-specificaties.md).
 
+## Snelle links
+
+**Referentiecomponenten**
+
+* [Zaakregistratiecomponent](https://github.com/vng-Realisatie/gemma-zaakregistratiecomponent)
+* [Documentregistratiecomponent](https://github.com/vng-Realisatie/gemma-documentregistratiecomponent)
+* [Zaaktypecatalogus](https://github.com/vng-Realisatie/gemma-zaaktypecatalogus)
+
+**Ondersteunende tooling**
+
+* [Gedeelde code tussen componenten](https://github.com/VNG-Realisatie/gemma-zaken-common)
+* [Overige registratiescomponent](https://github.com/VNG-Realisatie/gemma-mock-overigeregistratiecomponenten)
+* [Integratietesten](https://github.com/VNG-Realisatie/gemma-zaken-test-integratie)
+* [ZDS Client](https://github.com/VNG-Realisatie/gemma-zds-client)
+* [Demo applicatie(s)](https://github.com/VNG-Realisatie/gemma-zaken-demo)
+
 ## Licentie
 Copyright © VNG Realisatie 2018
 


### PR DESCRIPTION
1. Er was 1 kapotte link
2. Kopje 'snelle links' toegevoegd - er komen vaker opmerkingen dat mensen de weg kwijt zijn, en ik vind het zelf ook handiger om direct vanuit deze readme naar de andere repositories te kunnen doorklikken.

