### PR TITLE
rolomschrijvingGeneriek verwijderd

### DIFF
--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -115,20 +115,6 @@ paths:
               - Initiator
               - Klantcontacter
               - Zaakcoördinator
-        - name: rolomschrijvingGeneriek
-          in: query
-          description: Algemeen gehanteerde benaming van de aard van de ROL
-          required: false
-          schema:
-            type: string
-            enum:
-              - Adviseur
-              - Behandelaar
-              - Belanghebbende
-              - Beslisser
-              - Initiator
-              - Klantcontacter
-              - Zaakcoördinator
               - Mede-initiator
       responses:
         '200':
@@ -587,7 +573,6 @@ components:
         - betrokkene
         - betrokkeneType
         - rolomschrijving
-        - rolomschrijvingGeneriek
         - roltoelichting
       type: object
       properties:
@@ -619,18 +604,6 @@ components:
             - Medewerker
         rolomschrijving:
           title: Rolomschrijving
-          description: Algemeen gehanteerde benaming van de aard van de ROL
-          type: string
-          enum:
-            - Adviseur
-            - Behandelaar
-            - Belanghebbende
-            - Beslisser
-            - Initiator
-            - Klantcontacter
-            - Zaakcoördinator
-        rolomschrijvingGeneriek:
-          title: Rolomschrijving generiek
           description: Algemeen gehanteerde benaming van de aard van de ROL
           type: string
           enum:

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -272,6 +272,7 @@ paths:
               - Initiator
               - Klantcontacter
               - Zaakcoördinator
+              - Mede-initiator
       responses:
         '200':
           description: ''
@@ -754,6 +755,7 @@ components:
             - Initiator
             - Klantcontacter
             - Zaakcoördinator
+            - Mede-initiator
         mogelijkeBetrokkenen:
           type: array
           items:


### PR DESCRIPTION
**Wijzigingen**

[Browsable API spec](https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-45-zet-behandelaar/api-specificatie/zrc/openapi.yaml)

het veld `rolomschrijvingGeneriek` is verwijderd uit de API:

* er is geen expliciete vraag naar (vraag moet uit user stories komen)
* het is onduidelijk wat het verschil is met het veld `rolomschrijving`

We stellen dan ook een wijziging voor in het RGBZ om dit attribuut op een rol te verwijderen, bij gebrek aan praktische requirements voor dit veld/attribuut.

Merk ook op:

* `rolomschrijving` heeft een waardenverzameling (enum), gedefinieerd als AN80
* `rolomschrijvingGeneriek` heeft de waardenverzameling van `rolomschrijving` + `media-initiator`, gedefnieerd als AN40
* ImZTC heeft `rolomschrijvingGeneriek` met de waardenverzameling van `rolomschrijving`, gedefinieerd als AN20.

De consistentie is hier eigenlijk helemaal zoek, en die trekken we recht in deze API specs.