### PR TITLE
Gerelateerde objecten zonder eigen resource / Groepattributen

### DIFF
--- a/docs/content/developers/design-keuzes.md
+++ b/docs/content/developers/design-keuzes.md
@@ -110,7 +110,7 @@ De URLs in dit voorbeeld zijn uiteraard fictief.
 * Indien verwezen wordt naar een andere resource (relatie), wordt de volledige
   naam van de resource gebruikt als veldnaam. Voorbeeld: De resource `zaak`
   heeft een veld `zaaktype` en niet `type`. Ter vergelijking, in StUF-ZKN is
-  dit: `zaak-isVan-<zaak type data>` waar `isVan` verwijst naar het `zaaktype`.
+  dit: `zaak-isVan-<zaak type data>` waar `isVan` verwijst naar het  (een`zaaktype`.
 
   ```javascript
   {
@@ -121,14 +121,12 @@ De URLs in dit voorbeeld zijn uiteraard fictief.
   ```
 
 
-## Gerelateerde objecten zonder eigen resource / Groepsattributen
+## Groepsattributen
 
-Indien een (hoofd)object een gerelateerd object (of lijst van objecten) heeft,
-dat **geen** eigen resource URL nodig heeft, dan wordt het (child)object inline
-(binnen het hoofdobject) ontsloten. Deze child objecten zijn binnen RGBZ
-ook wel gedefinieerd als *groepsattributen*. Typische voorbeelden zijn
-(zaak-)kenmerken of (zaak-)eigenschappen waarin `Zaak` het hoofdobject betreft,
-en `Kenmerk` en `Eigenschap` de child objecten.
+Indien een object een groepattribuutsoort heeft (een groep van bij elkaar behorende attribuutsoorten), al dan niet herhalend d.w.z. kardinaliteit 1 of meer (een 'lijst' van waarden van de attributen van het groepattribuut), dan wordt het groepattribuut inline
+(binnen het object) ontsloten. Het krijgt dus geen eigen resource, het heeft immers geen zelfstandig bestaantsrecht. Het heeft alleen bestaansrecht als eigenschap van het object, net zoals attribuutsoorten. 
+Typische voorbeelden zijn (zaak-)kenmerken of (zaak-)eigenschappen waarin `Zaak` het hoofdobject betreft,
+en `Kenmerk` en `Eigenschap` de groepattributen.
 
 Voorbeeld:
 

--- a/docs/content/developers/design-keuzes.md
+++ b/docs/content/developers/design-keuzes.md
@@ -110,7 +110,7 @@ De URLs in dit voorbeeld zijn uiteraard fictief.
 * Indien verwezen wordt naar een andere resource (relatie), wordt de volledige
   naam van de resource gebruikt als veldnaam. Voorbeeld: De resource `zaak`
   heeft een veld `zaaktype` en niet `type`. Ter vergelijking, in StUF-ZKN is
-  dit: `zaak-isVan-<zaak type data>` waar `isVan` verwijst naar het  (een`zaaktype`.
+  dit: `zaak-isVan-<zaak type data>` waar `isVan` verwijst naar het `zaaktype`.
 
   ```javascript
   {
@@ -121,11 +121,11 @@ De URLs in dit voorbeeld zijn uiteraard fictief.
   ```
 
 
-## Groepsattributen
+## Groepattributen
 
-Indien een object een groepattribuutsoort heeft (een groep van bij elkaar behorende attribuutsoorten), al dan niet herhalend d.w.z. kardinaliteit 1 of meer (een 'lijst' van waarden van de attributen van het groepattribuut), dan wordt het groepattribuut inline
-(binnen het object) ontsloten. Het krijgt dus geen eigen resource, het heeft immers geen zelfstandig bestaantsrecht. Het heeft alleen bestaansrecht als eigenschap van het object, net zoals attribuutsoorten. 
-Typische voorbeelden zijn (zaak-)kenmerken of (zaak-)eigenschappen waarin `Zaak` het hoofdobject betreft,
+Indien een object een groepattribuutsoort heeft (een groep van bij elkaar behorende attribuutsoorten), al dan niet herhalend d.w.z. kardinaliteit nul of meer (een 'lijst' van waarden van de attributen van het groepattribuut), dan wordt het groepattribuut inline
+(binnen de resource voor het object) ontsloten. Het krijgt dus geen eigen resource, het heeft immers geen zelfstandig bestaansrecht. Het heeft alleen bestaansrecht als eigenschap van het object, net zoals attribuutsoorten. 
+Typische voorbeelden zijn (zaak-)kenmerken en (zaak-)eigenschappen waarin `Zaak` het hoofdobject betreft,
 en `Kenmerk` en `Eigenschap` de groepattributen.
 
 Voorbeeld:


### PR DESCRIPTION
Dit is een rare en m.i. onjuiste ontwerpkeuze. Er is, in het RGBZ, geen sprake van "een (hoofd)object [dat] een gerelateerd object (of lijst van objecten) heeft, dat geen eigen resource URL nodig heeft". Dit is een misvatting. Het RGBZ kent objecttypen die relaties met elkaar hebben. Indien een objecttype een eigen bestaansrecht heeft dan vraagt dat om uitwerking in een eigen resource. Kenmerken van dat objecttype maken deel uit van die resource. Kenmerken zijn attribuutsoorten. En die kunnen genest zijn: groepattributen. Maar ook dat blijven kenmerken van het objecttype, Dus geen enkele reden om dat uit te werken in een eigen resource.