### PR TITLE
Ref. #162 -- toevoeging BRC

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/spec-wijziging.md
+++ b/.github/PULL_REQUEST_TEMPLATE/spec-wijziging.md
@@ -52,8 +52,26 @@ aanpassingen:
 
 **Links**
 
-* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaaktypecatalous/pull/X)
+* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/X)
 * [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/<branch>/api-specificatie/ztc/openapi.yaml)
+
+
+**Wijzigingen**
+Deze uitbreiding (en aanpassing) op de spec heeft de volgende
+aanpassingen:
+
+* ...
+
+**Kanttekeningen**
+
+* ...
+
+## BRC
+
+**Links**
+
+* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-besluitregistratiecomponent/pull/X)
+* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/<branch>/api-specificatie/brc/openapi.yaml)
 
 
 **Wijzigingen**

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Zie de relevante links in dit [overzicht](docs/_content/ontwikkelaars/apis/).
 
 ## Snelle links
 
-**Referentiecomponenten**
+**Referentie-implementaties van componenten**
 
 * [Zaakregistratiecomponent](https://github.com/vng-Realisatie/gemma-zaakregistratiecomponent)
 * [Documentregistratiecomponent](https://github.com/vng-Realisatie/gemma-documentregistratiecomponent)
 * [Zaaktypecatalogus](https://github.com/vng-Realisatie/gemma-zaaktypecatalogus)
+* [Besluitregistratiecomponent](https://github.com/vng-Realisatie/gemma-besluitregistratiecomponent)
 
 **Ondersteunende tooling**
 

--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -944,7 +944,7 @@ components:
           title: Datum
           description: De beslisdatum (AWB) van het besluit.
           type: string
-          format: date-time
+          format: date
         toelichting:
           title: Toelichting
           description: Toelichting bij het besluit.

--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -949,7 +949,6 @@ components:
           title: Toelichting
           description: Toelichting bij het besluit.
           type: string
-          maxLength: 1000
         bestuursorgaan:
           title: Bestuursorgaan
           description: Een orgaan van een rechtspersoon krachtens publiekrecht ingesteld

--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -974,6 +974,14 @@ components:
           - tijdelijk
           - ingetrokken_overheid
           - ingetrokken_belanghebbende
+        vervalredenWeergave:
+          title: Vervalreden weergave
+          type: string
+          enum:
+          - Besluit met tijdelijke werking
+          - Besluit ingetrokken door overheid
+          - Besluit ingetrokken o.v.v. belanghebbende
+          readOnly: true
         publicatiedatum:
           title: Publicatiedatum
           description: Datum waarop het besluit gepubliceerd wordt.

--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -968,6 +968,18 @@ components:
           format: date
         vervalreden:
           title: Vervalreden
+          description: 'De omschrijving die aangeeft op grond waarvan het besluit
+            is of komt te vervallen.
+
+
+            De mapping van waarden naar weergave is als volgt:
+
+
+            * `tijdelijk` - Besluit met tijdelijke werking
+
+            * `ingetrokken_overheid` - Besluit ingetrokken door overheid
+
+            * `ingetrokken_belanghebbende` - Besluit ingetrokken o.v.v. belanghebbende'
           type: string
           enum:
           - tijdelijk
@@ -976,11 +988,8 @@ components:
         vervalredenWeergave:
           title: Vervalreden weergave
           type: string
-          enum:
-          - Besluit met tijdelijke werking
-          - Besluit ingetrokken door overheid
-          - Besluit ingetrokken o.v.v. belanghebbende
           readOnly: true
+          minLength: 1
         publicatiedatum:
           title: Publicatiedatum
           description: Datum waarop het besluit gepubliceerd wordt.

--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -331,8 +331,6 @@ paths:
 
         wordt ook door het systeem gezet.
 
-        - de combinatie informatieobject en object moet uniek zijn
-
 
         Bij het aanmaken wordt ook in de bron van het OBJECT de gespiegelde
 

--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -331,6 +331,8 @@ paths:
 
         wordt ook door het systeem gezet.
 
+        - de combinatie informatieobject en object moet uniek zijn
+
 
         Bij het aanmaken wordt ook in de bron van het OBJECT de gespiegelde
 

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -772,7 +772,7 @@ paths:
           - Beslisser
           - Initiator
           - Klantcontacter
-          - "Zaakco\xC3\xB6rdinator"
+          - "Zaakco\xF6rdinator"
           - Mede-initiator
       responses:
         '200':
@@ -1108,7 +1108,7 @@ paths:
     get:
       operationId: catalogus_read
       description: "De verzameling van ZAAKTYPEn - incl. daarvoor relevante objecttypen\
-        \ - voor een Domein die als \xC3\xA9\xC3\xA9n geheel beheerd\nwordt."
+        \ - voor een Domein die als \xE9\xE9n geheel beheerd\nwordt."
       responses:
         '200':
           description: ''
@@ -1349,7 +1349,6 @@ components:
           description: De generieke tekst van de publicatie van BESLUITen van dit
             BESLUITTYPE
           type: string
-          maxLength: 1000
         publicatietermijn:
           title: Publicatietermijn
           description: Het aantal dagen, gerekend vanaf de verzend- of publicatiedatum,
@@ -1359,7 +1358,6 @@ components:
           title: Toelichting
           description: Een eventuele toelichting op dit BESLUITTYPE.
           type: string
-          maxLength: 1000
         informatieobjecttypes:
           type: array
           items:
@@ -1609,7 +1607,7 @@ components:
           - Beslisser
           - Initiator
           - Klantcontacter
-          - "Zaakco\xC3\xB6rdinator"
+          - "Zaakco\xF6rdinator"
           - Mede-initiator
         mogelijkeBetrokkenen:
           type: array

--- a/docs/_content/introductie/begrippenlijst.md
+++ b/docs/_content/introductie/begrippenlijst.md
@@ -6,7 +6,8 @@ weight: 10
 
 In onderstaande begrippenlijst worden begrippen zoals deze gebruikt worden in de verschillende content van deze repository toegelicht.
 
-- API: (TODO)
+- API: Application Programming Interface - dit is een publieke, technologie-onafhankelijke interface voor gegevensuitwisseling tussen betrokken partijen.
+- BRC: Besluitregistratiecomponent. Component voor opslag en ontsluiting van (zaak)besluiten.
 - BSM: Bericht Structuur Model, een UML klassediagram dat  is afgeleid van het UGM waarmee de structuur van een specifiek bericht wordt vastgelegd.
 - CRUD: CRUD is een afkorting uit de informatica die staat voor de vier basisoperaties die op duurzame gegevens (meestal een database) uitgevoerd kunnen worden. Deze zijn:
 

--- a/docs/_content/ontwikkelaars/algemeen/standaard.md
+++ b/docs/_content/ontwikkelaars/algemeen/standaard.md
@@ -18,6 +18,7 @@ tussen registraties en consumers die van de API's gebruik maken.
 
 - [Beschikbaar stellen van API-spec](#beschikbaar-stellen-van-api-spec)
 - [Definities](#definities)
+- [Gegevensformaten](#gegevensformaten)
 - [Zaakregistratiecomponent](#zaakregistratiecomponent)
     - [OpenAPI specificatie](#openapi-specificatie)
     - [Run-time gedrag](#run-time-gedrag)
@@ -56,6 +57,16 @@ Voorbeelden van geldige URLs:
 
 De service-naar-service communicatie MOET het schema opvragen om operaties op
 resources uit te voeren.
+
+## Gegevensformaten
+
+Een aantal formaten zijn nog niet formeel vastgelegd in OAS of JSON-Schema,
+echter deze worden wel binnen de ZDS APIs gebruikt en opgelegd.
+
+### Duur
+
+Een duur (EN: duration) MOET in [ISO-8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+uitgedrukt worden.
 
 ## Zaakregistratiecomponent
 

--- a/docs/_content/ontwikkelaars/algemeen/standaard.md
+++ b/docs/_content/ontwikkelaars/algemeen/standaard.md
@@ -285,14 +285,16 @@ aanscherpen)
 
 #### Garanderen uniciteit `verantwoordelijke_organisatie` en `identificatie` op de `Besluit`-resource
 
-Bij het aanmaken (`besluit_create`) en bijwerken (`besluit_update` en
-`besluit_partial_update`) MOET gevalideerd worden dat de combinatie `identificatie`
-en `verantwoordelijke_organisatie` uniek is, indien de `identificatie` door de consumer
-meegestuurd wordt.
+Bij het aanmaken (`besluit_create`) MOET gevalideerd worden dat de combinatie
+`identificatie` en `verantwoordelijke_organisatie` uniek is, indien de
+`identificatie` door de consumer meegestuurd wordt.
 
 Indien de identificatie niet door de consumer gestuurd wordt, dan MOET het BRC
 de identificatie genereren op een manier die garandeert dat de identificatie
 uniek is binnen de verantwoordelijke_organisatie.
+
+Bij het bijwerken (`besluit_update` en `besluit_partial_update`) is het NIET
+TOEGESTAAN om `identificatie` en `verantwoordelijke_organisatie` te wijzingen.
 
 #### Valideren `informatieobject` op de `BesluitInformatieObject`-resource
 

--- a/docs/_content/ontwikkelaars/algemeen/standaard.md
+++ b/docs/_content/ontwikkelaars/algemeen/standaard.md
@@ -139,7 +139,6 @@ Het is NIET TOEGESTAAN om gebruik te maken van operaties die niet beschreven
 staan in deze OAS spec, of om uitbreidingen op operaties in welke vorm dan ook
 toe te voegen.
 
-
 ### Run-time gedrag
 
 Bepaalde gedrageningen kunnen niet in een OAS spec uitgedrukt worden omdat ze

--- a/docs/_content/ontwikkelaars/apis/brc.md
+++ b/docs/_content/ontwikkelaars/apis/brc.md
@@ -6,7 +6,14 @@ date: '14-11-2018'
 *Component voor opslag en ontsluiting van besluiten en daarbij behorende metadata.*
 
 Dit component is losgetrokken van het ZRC om besluiten vast te leggen van Zaken
-en andere objecten.
+-en andere objecten.
+
+De component ondersteunt het opslaan en het naar andere applicaties ontsluiten
+van gegevens over alle gemeentelijke besluiten, van elk type. Opslag vindt plaats
+conform het RGBZ waarin objecten, gegevens daarvan en onderlinge relaties zijn
+beschreven. Het bevat echter niet alle gegevens uit het RGBZ: documenten worden
+opgeslagen in de documentenregistratiecomponent, medewerkergegevens in de
+medewerkerregistratiecomponent, etc.
 
 ## Verwijzingen
 

--- a/docs/_content/overige/functioneel/ontwerpkeuzes-informatiemodellen.md
+++ b/docs/_content/overige/functioneel/ontwerpkeuzes-informatiemodellen.md
@@ -3,5 +3,14 @@ title: "Ontwerpkeuzes informatiemodellen"
 date: '28-8-2018'
 ---
 
-Bij het ontwikkelen van de API's aam de hand van user-story's kan voortschrijdend inzicht er toe leiden dat in de API cq. resource afgeweken wordt van het desbetreffende informatiemodel, i.c. RGBZ of ImZTC. Het desbetreffende informatiemodel moet daarop aangepast worden. Ook kan een (generieke) ontwerpkeuze (zie hier) als consequentie hebbe dat een informatiemodel aangpast moet worden.
-Hieronder vermelden we de gemaakte keuzes tot aanpassing van RGBZ en ImZTC.
+# Ontwerpkeuzes informatiemodellen
+
+Bij het ontwikkelen van de API's aan de hand van userstories kan
+voortschrijdend inzicht er toe leiden dat in de API resources afgeweken wordt
+van het desbetreffende informatiemodel (RGBZ of ImZTC). Het desbetreffende
+informatiemodel moet daarop aangepast worden. Ook kan een (generieke)
+ontwerpkeuze (zie hier) als consequentie hebbe dat een informatiemodel aangpast
+moet worden. Hieronder vermelden we de gemaakte keuzes tot aanpassing van
+RGBZ en ImZTC.
+
+## ...

--- a/docs/_content/overige/technisch/design-keuzes.md
+++ b/docs/_content/overige/technisch/design-keuzes.md
@@ -168,6 +168,36 @@ Noot 2: authenticatie en authorisatie worden in een later stadium uitgewerkt.
 Het is bekend dat hier goed over nagedacht moet worden.
 
 
+## Documenteren (input)validatie
+
+De [input validatie](#input-validatie) kan enkel in tekstuele vorm in de OAS
+api-spec opgenomen worden. We houden het formaat:
+
+```md
+Er wordt gevalideerd op:
+- geldigheid besluit URL
+- geldigheid informatieobject URL
+```
+
+Deze documentatie wordt opgenomen in de `description` key voor de operation
+(bijvoorbeeld `besluitinformatieobject_create`).
+
+Voorbeeld:
+
+```yaml
+paths:
+  /besluiten:
+    post:
+      operationId: besluitinformatieobject_create
+      description: |-
+        Registreer in welk(e) INFORMATIEOBJECT(en) een BESLUIT vastgelegd is.
+
+        Er wordt gevalideerd op:
+        - geldigheid besluit URL
+        - geldigheid informatieobject URL
+```
+
+
 ## Besluitenregistratie (BRC)
 
 Er komt een aparte besluitenregistratie (naast ZRC, ZTC en DRC) om besluiten

--- a/docs/_content/overige/technisch/dev-straat.md
+++ b/docs/_content/overige/technisch/dev-straat.md
@@ -33,6 +33,7 @@ Iedere referentieimplementatie van een component leeft in zijn eigen repository:
 * [ZRC](https://github.com/vng-Realisatie/gemma-zaakregistratiecomponent)
 * [DRC](https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent)
 * [ZTC](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus)
+* [BRC](https://github.com/VNG-Realisatie/gemma-besluitregistratie)
 
 Voor de referentieimplementaties wordt het git-flow git-branching model
 aangehouden. Dit houdt in dat de `master` branch de huidige stabiele,
@@ -125,6 +126,7 @@ De referentieimplementaties zijn gehost op:
 * ZRC: https://ref.tst.vng.cloud/zrc/api/v1/
 * DRC: https://ref.tst.vng.cloud/drc/api/v1/
 * ZTC: https://ref.tst.vng.cloud/ztc/api/v1/
+* BRC: https://ref.tst.vng.cloud/brc/api/v1/
 
 Merk op dat dit testomgevingen zijn waar geen enkele garantie van stabiliteit
 is. In een latere fase komen er stabiele omgevingen.

--- a/infra/brc/postgres.yml
+++ b/infra/brc/postgres.yml
@@ -1,0 +1,55 @@
+---
+
+# Deployment
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: postgres-brc
+  namespace: gemma
+  labels:
+    k8s-app: postgres-brc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: postgres-brc
+  template:
+    metadata:
+      name: postgres-brc
+      labels:
+        k8s-app: postgres-brc
+    spec:
+      volumes:
+      - name: data
+        hostPath:
+          path: "/storage/gemma-postgres-brc"
+          type: ''
+      containers:
+      - name: postgres
+        image: mdillon/postgis
+        env:
+          - name: POSTGRES_PASSWORD
+            value: <REDACTED>
+        volumeMounts:
+          - name: data
+            mountPath: "/var/lib/postgresql/data"
+
+---
+
+# Service
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: postgres-brc
+  namespace: gemma
+  labels:
+    k8s-app: postgres-brc
+spec:
+  selector:
+    k8s-app: postgres-brc
+  ports:
+  - protocol: TCP
+    port: 5432
+    targetPort: 5432

--- a/infra/brc/web.yml
+++ b/infra/brc/web.yml
@@ -1,0 +1,57 @@
+---
+
+# Deployment
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: brc
+  namespace: gemma
+  labels:
+    k8s-app: brc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: brc
+  template:
+    metadata:
+      name: brc
+      labels:
+        k8s-app: brc
+    spec:
+      containers:
+      - name: brc
+        image: vngr/gemma-brc:0.1.0
+        env:
+          - name: DJANGO_SETTINGS_MODULE
+            value: brc.conf.docker
+          - name: SUBPATH
+            value: /brc
+          - name: DATABASE_HOST
+            value: postgres-brc
+          - name: SECRET_KEY
+            value: <REDACTED>
+          - name: DATABASE_PASSWORD
+            value: <REDACTED>
+          - name: SENTRY_DSN
+            value: <REDACTED>
+
+---
+
+# Service
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: brc
+  namespace: gemma
+  labels:
+    k8s-app: brc
+spec:
+  selector:
+    k8s-app: brc
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -22,6 +22,11 @@ services:
     volumes:
       - ztc_postgres_data:/var/lib/postgresql/data
 
+  brc_db:
+    image: postgres
+    volumes:
+      - brc_postgres_data:/var/lib/postgresql/data
+
   # web
   zrc_web:
     image: vngr/gemma-zrc:latest
@@ -52,8 +57,20 @@ services:
     depends_on:
       - ztc_db
 
+  brc_web:
+    image: vngr/gemma-brc:latest
+    environment:
+      - DJANGO_SETTINGS_MODULE=brc.conf.docker
+      - SECRET_KEY=u=y-#vjs0lw^%d13s8i=7r-880=-%5v!vmyzdoo=2go%ana4rc
+      - DATABASE_HOST=brc_db
+    ports:
+      - 8003:8000
+    depends_on:
+      - brc_db
+
 volumes:
   zrc_postgres_data:
   drc_postgres_data:
   drc_media:
   ztc_postgres_data:
+  brc_postgres_data:

--- a/infra/ingress.yml
+++ b/infra/ingress.yml
@@ -33,6 +33,10 @@ spec:
         backend:
           serviceName: ztc
           servicePort: 8000
+      - path: "/brc/"
+        backend:
+          serviceName: brc
+          servicePort: 8000
       - path: "/"
         backend:
           serviceName: zaken-docs


### PR DESCRIPTION
# API specificatie aanpassing

Deze aanpassing omvat het toevoegen van de besluitregistratiecomponent (BRC). 
De BRC bevat `BESLUIT` zoals deze in RGBZ beschreven staan per juni 2018 en 
`BESLUITINFORMATIEOBJECT` om de relatie tussen besluiten en informatieobjecten
langs de BRC kant te ontsluiten.

* Zie: [User Story](https://github.com/VNG-Realisatie/gemma-zaken/issues/162)
* Zie: [Architectuurschets](https://github.com/VNG-Realisatie/gemma-zaken/issues/171)

## ZRC
Geen aanpassingen.

## DRC
Geen aanpassingen anders dan in #166.

## ZTC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/10)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-162-brc/api-specificatie/ztc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Toevoeging `BesluitType` resource aan de API
* Vanuit de `Catalogus` resource worden de `besluittypen` ook ontsloten
* Ontsluit velden uit `ImZTC` en `RGBZ` (gebaseerd op Haarlem ZTC)

**Kanttekeningen**

* Uit de RGBZ bechrijving klinkt het alsof `omschrijving_generiek` een `ENUM`
  zou moeten zijn (landelijke lijst van namen/omschrijvingen), maar deze is
  nergens terug te vinden (@ArjanKloosterboer)
* Uit de RGBZ beschrijving volgt dat de waardenverzameling voor `besluitcategorie`
  gebaseerd is op de AWB, echter deze waardenverzameling is ons niet bekend.
  Dit veld zou dus ook een `ENUM` moeten zijn. (@ArjanKloosterboer)
*  `reactietermijn` en `publicatietermijn` zijn nu ISO-8601 durations, per
  de designkeuzes in `docs/content/developers/design-keuzes.md`
* `reactietermijn` heeft kardinaliteit 1-1 in het RGBZ, echter er wordt 
  onderkend dat dit mogelijks niet van toepassing is (waarbij dan 0 dagen)
  gebruikt moet worden. In het kader van normalisering is de `null` waarde
  hier toegestaan, wat het effectief kardinaliteit 0-1 maakt

## BRC

**Links**

* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/vng-Realisatie/gemma-zaken/feature/us-162-brc/api-specificatie/brc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Toevoeging resource `BESLUIT` met attributen:
    * `identificatie`
    * `verantwoordelijkeOrganisatie` (verplicht)
    * `besluittype` (verplicht)
    * `zaak`
    * `datum` (verplicht)
    * `toelichting`
    * `bestuursorgaan`
    * `ingangsdatum` (verplicht)
    * `vervaldatum`
    * `vervalreden`
    * `publicatiedatum`
    * `verzenddatum`
    * `uiterlijkeReactiedatum`
* Validatie op URL-referenties (URL opvragen mag geen fout veroorzaken)
* Validatie op unieke combinatie `verantwoordelijkeOrganisatie` en `identificatie`
* Foutmeldingen crf. DSO API-50 en andere DSO richtlijnen uit ZRC/DRC/ZTC
  opgenomen.
* Toevoeging `BesluitInformatieObject` resource als sub-resource van `Besluit`. Deze bestaat zodat meteen helder is welke informatieobjecten het besluit vastleggen. Dezelfde regels gelden hier als de `ZaakInformatieObject` resource in het ZRC.

**Kanttekeningen**

* het `datum` veld is als `datetime` gemodelleerd. Het RGBZ schrijft voor dat
  dit veld niet later dan 'nu' mag zijn (er is expliciet sprake van een 
  tijdaspect). I.v.m. technische eisen om die validatie te kunnen doen cfr. 
  ISO 8601 moet er tijdszoneinformatie meegegeven worden, wat met `date`
  objecten niet mogelijk is, alleen met `datetime`.

* Het `vervalreden` attribuut is in het RGBZ-concept niet volledig uitgewerkt,
  er staan geen waardes. Deze zijn op basis van de naam/titel aangemaakt, en
  keren terug in de enum als:

  ```yaml
  vervalreden:
    title: Vervalreden
    type: string
    enum:
      - tijdelijk
      - ingetrokken_overheid
      - ingetrokken_belanghebbende
  ```

# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
- [x] Wijzigingen duidelijk omschreven en akkoord (@michielverhoef)
- [ ] Voldoet aan RGBZ of afwijkingen zijn akkoord (@ArjanKloosterboer)
- [x] Voldoet aan GEMMA architectuur of afwijkingen zijn akkoord (@jgortmaker1)
