### PR TITLE
Ontwerp keuzes documenteren en controleren in DoD

### DIFF
--- a/.github/ISSUE_TEMPLATE/als-----wil-ik----.md
+++ b/.github/ISSUE_TEMPLATE/als-----wil-ik----.md
@@ -24,6 +24,8 @@ about: Beschrijving van een feature/user story
 - [ ] de specificatie is gepubliceerd leesbaar
 - [ ] er is een referentieimplementatie
 - [ ] de DSO URI- en API-strategie worden gevolgd
+- [ ] eventueel gemaakte ontwerp keuzes zijn gedocumenteerd
+- [ ] er zijn geen (nieuwe) conflicten met ontwerp keuzes in [BIP](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/docs/design_decisions.md)
 
 **Acceptatiecriteria**
 Uit de algemene uitgangspunten:


### PR DESCRIPTION
Uit overleg is gebleken dat er een parallel traject is waar ook ontwerp keuzes worden gemaakt. We moeten zorgen dat deze niet met elkaar conflicteren. Het afwijken van ontwerp keuzes kan vooralsnog wel, maar conflicten zoveel mogelijk vermijden totdat VNG de ontwerp keuzes centraal bijhoudt.