### PR TITLE
Fixes #491 -- leg aard relatie vast

### DIFF
--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -307,7 +307,15 @@ paths:
       - objectinformatieobjecten
     post:
       operationId: objectinformatieobject_create
-      description: 'Registreer een INFORMATIEOBJECT bij een OBJECT.
+      description: 'Registreer een INFORMATIEOBJECT bij een OBJECT. Er worden twee
+        types van
+
+        relaties met andere objecten gerealiseerd:
+
+
+        * INFORMATIEOBJECT behoort bij [OBJECT] en
+
+        * INFORMATIEOBJECT is vastlegging van [OBJECT].
 
 
         Er wordt gevalideerd op:
@@ -319,7 +327,9 @@ paths:
         - de combinatie informatieobject en object moet uniek zijn
 
 
-        De registratiedatum wordt door het systeem op ''NU'' gezet.
+        De registratiedatum wordt door het systeem op ''NU'' gezet. De aard_relatie
+
+        wordt ook door het systeem gezet.
 
 
         Bij het aanmaken wordt ook in de bron van het OBJECT de gespiegelde
@@ -327,9 +337,9 @@ paths:
         relatie aangemaakt, echter zonder de relatie-informatie.
 
 
-        Titel en beschrijving zijn enkel relevant als het om een
+        Titel, beschrijving en registratiedatum zijn enkel relevant als het om een
 
-        object van het type ZAAK gaat.'
+        object van het type ZAAK gaat (aard relatie "hoort bij").'
       responses:
         '201':
           description: ''
@@ -475,9 +485,9 @@ paths:
         - informatieobject URL, object URL en objectType mogen niet veranderen
 
 
-        Titel en beschrijving zijn enkel relevant als het om een
+        Titel, beschrijving en registratiedatum zijn enkel relevant als het om een
 
-        object van het type ZAAK gaat.'
+        object van het type ZAAK gaat (aard relatie "hoort bij").'
       responses:
         '200':
           description: ''
@@ -1916,7 +1926,6 @@ components:
       - informatieobject
       - object
       - objectType
-      - aardRelatie
       type: object
       properties:
         url:
@@ -1941,17 +1950,13 @@ components:
           enum:
           - besluit
           - zaak
-        aardRelatie:
-          title: Aard relatie
-          type: string
-          enum:
-          - hoort_bij
-          - legt_vast
         aardRelatieWeergave:
           title: Aard relatie weergave
           type: string
+          enum:
+          - 'Hoort bij, omgekeerd: kent'
+          - 'Legt vast, omgekeerd: kan vastgelegd zijn als'
           readOnly: true
-          minLength: 1
         titel:
           title: Titel
           description: De naam waaronder het INFORMATIEOBJECT binnen het OBJECT bekend

--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -1916,6 +1916,7 @@ components:
       - informatieobject
       - object
       - objectType
+      - aardRelatie
       type: object
       properties:
         url:
@@ -1940,6 +1941,17 @@ components:
           enum:
           - besluit
           - zaak
+        aardRelatie:
+          title: Aard relatie
+          type: string
+          enum:
+          - hoort_bij
+          - legt_vast
+        aardRelatieWeergave:
+          title: Aard relatie weergave
+          type: string
+          readOnly: true
+          minLength: 1
         titel:
           title: Titel
           description: De naam waaronder het INFORMATIEOBJECT binnen het OBJECT bekend

--- a/standaard.md
+++ b/standaard.md
@@ -168,11 +168,20 @@ een `HTTP 400` foutbericht.
 
 #### Valideren relatieinformatie op `ObjectInformatieObject`-resource
 
-De resource bevat de velden `titel` en `beschrijving`. Deze velden zijn enkel
-van toepassing op het `objectType` `zaak` en moeten genegeerd worden bij het
-`objectType` `besluit`.
+Op basis van het `objectType` MOET de `aardRelatie` gezet worden conform het
+RGBZ. Dit betekent:
 
-De `registratiedatum` moet door het systeem gezet worden op het moment van
+* `aardRelatie` is `"hoort_bij"`, indien `objectType`:
+    * `zaak`
+
+* `aardRelatie` is `"legt_vast"`, indien `objectType`:
+    * `besluit`
+
+De resource bevat de velden `titel`, `beschrijving` en `registratiedatum`. Deze
+velden zijn enkel van toepassing op `aardRelatie` `"hoort_bij"` en MOETEN
+genegeerd worden bij `aardRelatie` `"legt_vast"`.
+
+De `registratiedatum` MOET door het systeem gezet worden op het moment van
 aanmaken.
 
 Bij het updaten (`objectinformatieobject_update` en


### PR DESCRIPTION
# API specificatie aanpassing

Tussen objecten en informatieobjecten bestaan relaties. De aard van de relatie
kent twee distinctieve mogelijkheden (kent / kan vastgelegd zijn als) en moet
verplicht meegegeven worden. Dit wordt toegevoegd aan het ZRC.

De systeemwaarden zijn kort en tonen zich als een enum, de menselijk-leesbare
weergave is als alleen-lezen veld opgenomen.

* Zie: [User Story](https://github.com/VNG-Realisatie/gemma-zaken/issues/491)

## ZRC

Geen wijzigingen.

## DRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/pull/21)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/issue-491-drc-aard-relatie/api-specificatie/drc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Toevoegen enum `aardRelatie` met waardes `hoort_bij` en `legt_vast`
* Toevoegen alleen-lezen veld `aardRelatieWeergave` wat de weergave voor de 
  eindgebruiker van `aardRelatie` bevat.

## ZTC

Geen aanpassingen.

# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
- [x] Voldoet aan RGBZ of afwijkingen zijn akkoord (@ArjanKloosterboer)
- [x] ~~Voldoet aan GEMMA architectuur of afwijkingen zijn akkoord (@jgortmaker1)~~ n.v.t.
