### PR TITLE
Fixes #518 -- added status filter on zaak & statustype

### DIFF
--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -271,7 +271,7 @@ paths:
           - Beslisser
           - Initiator
           - Klantcontacter
-          - "Zaakco\xC3\xB6rdinator"
+          - "Zaakco\xF6rdinator"
           - Mede-initiator
       responses:
         '200':
@@ -484,6 +484,21 @@ paths:
     get:
       operationId: status_list
       description: ''
+      parameters:
+      - name: zaak
+        in: query
+        description: URL to the related resource
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: statusType
+        in: query
+        description: ''
+        required: false
+        schema:
+          type: string
+          format: uri
       responses:
         '200':
           description: ''
@@ -2069,7 +2084,7 @@ components:
           - Beslisser
           - Initiator
           - Klantcontacter
-          - "Zaakco\xC3\xB6rdinator"
+          - "Zaakco\xF6rdinator"
           - Mede-initiator
         roltoelichting:
           title: Roltoelichting


### PR DESCRIPTION
# API specificatie aanpassing

[beschrijf overkoepelend wat de aanpassingen zijn. Hieronder kan je in meer
detail per component omschrijven wat er gewijzigd is]

* Zie: [User Story](https://github.com/VNG-Realisatie/gemma-zaken/issues/518)

## ZRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/22)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-518-filter-status/api-specificatie/zrc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Op de `Status` resource zijn filters toegevoegd:
    * `zaak`: URL naar de zaak om op te filteren
    * `statusType`: URL van het statusType in de zaaktypecatalogus

## DRC

Geen wijzigingen

## ZTC

Geen wijzigingen

# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
