### PR TITLE
Feature/scopes

### DIFF
--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: EUPL 1.2
   version: '1'
 security:
-- basic: []
+- JWT-Claims: []
 paths:
   /klantcontacten:
     get:
@@ -398,6 +398,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - rollen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.aanmaken
       requestBody:
         content:
           application/json:
@@ -558,6 +561,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - statussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
     post:
       operationId: status_create
       description: ''
@@ -624,6 +630,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - statussen
+      security:
+      - JWT-Claims:
+        - (zds.scopes.zaken.aanmaken | zds.scopes.statussen.toevoegen)
       requestBody:
         content:
           application/json:
@@ -698,6 +707,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - statussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
     parameters:
     - name: uuid
       in: path
@@ -769,6 +781,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaakobjecten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
     post:
       operationId: zaakobject_create
       description: Registreer een ZAAKOBJECT relatie.
@@ -835,6 +850,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaakobjecten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.aanmaken
       requestBody:
         content:
           application/json:
@@ -909,6 +927,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaakobjecten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
     parameters:
     - name: uuid
       in: path
@@ -1026,6 +1047,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
     post:
       operationId: zaak_create
       description: 'Maak een ZAAK aan.
@@ -1116,6 +1140,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.aanmaken
       requestBody:
         $ref: '#/components/requestBodies/Zaak'
     parameters: []
@@ -1213,6 +1240,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
       requestBody:
         content:
           application/json:
@@ -1312,6 +1342,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
     put:
       operationId: zaak_update
       description: Opvragen en bewerken van ZAAKen.
@@ -1900,9 +1933,10 @@ components:
             $ref: '#/components/schemas/Zaak'
       required: true
   securitySchemes:
-    basic:
+    JWT-Claims:
+      bearerFormat: JWT
+      scheme: bearer
       type: http
-      scheme: basic
   schemas:
     KlantContact:
       required:

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -53,8 +53,7 @@ info:
     name: EUPL 1.2
   version: '1'
 security:
-- Bearer: []
-- OAuth2: []
+- JWT-Claims: []
 paths:
   /catalogussen:
     get:
@@ -119,6 +118,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters: []
   /catalogussen/{catalogus_uuid}/besluittypen:
     get:
@@ -186,6 +188,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -261,6 +266,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -339,6 +347,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -415,6 +426,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -493,6 +507,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -569,6 +586,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -647,6 +667,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -732,6 +755,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -833,6 +859,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -916,6 +945,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1000,6 +1032,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1082,6 +1117,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1172,6 +1210,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - catalogussen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
     parameters:
     - name: uuid
       in: path
@@ -1184,18 +1225,10 @@ servers:
 - url: /api/v1
 components:
   securitySchemes:
-    Bearer:
-      in: header
-      name: Authorization
-      type: apiKey
-    OAuth2:
-      type: oauth2
-      flows:
-        clientCredentials:
-          tokenUrl: /oauth2/token/
-          scopes:
-            write: Schrijftoegang tot de catalogus en gerelateerde objecten.
-            read: Leestoegang tot de catalogus en gerelateerde objecten.
+    JWT-Claims:
+      bearerFormat: JWT
+      scheme: bearer
+      type: http
   schemas:
     Catalogus:
       required:

--- a/docs/_content/ontwikkelaars/algemeen/standaard.md
+++ b/docs/_content/ontwikkelaars/algemeen/standaard.md
@@ -93,8 +93,10 @@ server MOET aan de hand van de `client_identifier` key in de JWT header
 de bijhorende secret opvragen. De server MOET met het juiste shared secret
 het JWT valideren tegen tampering.
 
-De payload in het token bevat de scopes als lijst van strings, waarbij de
-`scopes` key gebruikt wordt.
+De ZDS claims in de JWT-payload worden genamespaced onder `zds`.
+
+De claims bevatten de scopes als lijst van strings, waarbij de `scopes` key
+gebruikt wordt.
 
 De `zaaktypes` claim MOET gebruikt worden om zaakgegevens te limiteren. Indien
 deze claim ontbreekt, `null` is of een lege lijst, dan is het VERBODEN om
@@ -105,13 +107,15 @@ Voorbeeld van een payload:
 
 ```json
 {
-    "scopes": [
-        "zds.scopes.zaken.aanmaken"
-    ],
-    "zaaktypes": [
-        "https://haarlem.ztc.nl/api/v1/zaaktypen/123",
-        "https://haarlem.ztc.nl/api/v1/zaaktypen/124",
-    ]
+    "zds": {
+        "scopes": [
+            "zds.scopes.zaken.aanmaken"
+        ],
+        "zaaktypes": [
+            "https://haarlem.ztc.nl/api/v1/zaaktypen/123",
+            "https://haarlem.ztc.nl/api/v1/zaaktypen/124",
+        ]
+    }
 }
 ```
 

--- a/docs/_content/ontwikkelaars/algemeen/standaard.md
+++ b/docs/_content/ontwikkelaars/algemeen/standaard.md
@@ -19,6 +19,7 @@ tussen registraties en consumers die van de API's gebruik maken.
 - [Beschikbaar stellen van API-spec](#beschikbaar-stellen-van-api-spec)
 - [Definities](#definities)
 - [Gegevensformaten](#gegevensformaten)
+- [Autorisatie](#autorisatie)
 - [Zaakregistratiecomponent](#zaakregistratiecomponent)
     - [OpenAPI specificatie](#openapi-specificatie)
     - [Run-time gedrag](#run-time-gedrag)
@@ -42,6 +43,15 @@ tussen registraties en consumers die van de API's gebruik maken.
 
 - 'Uiteindelijk resulteren' betekent dat redirects (`HTTP 301`, `HTTP 302`)
   toegestaan zijn, mits deze redirect-locatie resulteert in een `HTTP 200`.
+
+- Autorisatie: het mechanisme om wel of niet toegang te verlenen tot operaties
+  en/of gegevens in de APIs. Niet te verwarren met authenticatie.
+
+- Authenticatie: het mechanisme om de identiteit van een een persoon of andere
+  entiteit vast te stellen.
+
+- Eindgebruiker: de persoon die gebruik maakt van een (taak)applicatie die
+  communiceert via de ZDS APIs.
 
 ## Beschikbaar stellen van API-spec
 
@@ -67,6 +77,34 @@ echter deze worden wel binnen de ZDS APIs gebruikt en opgelegd.
 
 Een duur (EN: duration) MOET in [ISO-8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
 uitgedrukt worden.
+
+## Autorisatie
+
+De API-endpoints vereisen autorisatie, in de minimale vorm met scopes. Deze
+scopes zijn opgenomen in de OAS spec.
+
+API requests van clients MOETEN een
+[JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519) versturen naar de
+API. Dit token MOET in de `Authorization` HTTP header opgenomen worden.
+
+Client en server maken gebruik van `shared secret` om het JWT te signen, met
+het HMAC SHA-256 algoritme.
+
+De payload in het token bevat de scopes als lijst van strings, waarbij de
+`scopes` key gebruikt wordt. Voorbeeld:
+
+```json
+{
+    "scopes": [
+        "zds.scopes.zaken.aanmaken"
+    ]
+}
+```
+
+Later MOETEN andere claims ondersteund worden, zoals zaaktypen waar de
+eindgebruiker rechten op heeft.
+
+(TODO: specifieer hoe secrets limiteren tot 1 client)
 
 ## Zaakregistratiecomponent
 

--- a/docs/_content/ontwikkelaars/apis/scopes.md
+++ b/docs/_content/ontwikkelaars/apis/scopes.md
@@ -4,7 +4,15 @@
 - roltypen
 - AVG/privacy
 
+## Algemeen
+[bijdrage Arjan]<br>
+De mogelijkheden voor een gebruiker om gegevens van een object, zoals Zaak 1234 of Document Abcd, te mogen raadplegen en bewerken (cq. om een operatie op een - voorkomen in een - resource uit te voeren) hangen m.i. af van (minimaal) vier factoren.
+1) **_De categorie van het object_**. Bijvoorbeeld het zaaktype van een zaak, of een zaak al dan niet beeindigd is, etc. Zo zal een gebruiker veelal slechts zaken van bepaalde zaaktypen mogen raadplegen, of alleen onderhanden zaken. 
+2) **_De betrokkenheid van de gebruiker bij het object_**. Voor sommige objecten kan hiervan sprake zijn, bijvoorbeeld zaken (betrokkenen in rollen), veelal is hiervan voor andere objecten geen sprake (zoals zaaktype). Zo zijn de mogelijheden voor een gebruiker zijnde een Behandelaar van een Zaak anders dan een Initiator van een zaak en geheel anders dan een gebruiker die geen Rol heeft als Betrokkene bij de zaak. 
+3) **_De categorie van het gegeven (van het object)_** De gebruiker wil iets met een gegeven (of relatie) van het object (of met een groep gegevens). Met het ene gegeven zal hij/zij meer mogen dan met een ander gegeven. Het maakt bijvoorbeeld nogal uit of het om persoonsgegevens gaat of om archiveringsgegevens. 
+4) **_De mate van vertrouwelijkheid van het gegeven (van het object)_**. Ook al zou een gebruiker op grond van de voorgaande factoren het gegeven mogen raadplegen, dan nog kan het zijn dat hij/zij dat vanwege een bepaalde mate van vertrouwelijkheid toch niet mag.
 
+[uitwerken op de dwarsdoorsnedes van deze factoren, te beginnen met rollen versus vertrouwelijkheidniveau's]
 
 
 ## Op basis van roltype:

--- a/docs/_content/ontwikkelaars/apis/scopes.md
+++ b/docs/_content/ontwikkelaars/apis/scopes.md
@@ -217,6 +217,8 @@ Mogelijks subtypes:
 
 Dit is heel erg WIP - we zoeken een goede balans!
 
+Een `✓` betekent dat het in de referentieimplementatie gebouwd is.
+
 ### Zaken openbaar lezen
 
 **Label**
@@ -245,7 +247,7 @@ Superset van `zds.scopes.zaken.lezen.openbaar`
 * Kan alle statussen van zaken lezen, met alle attributen
 * Kan alle zaakobjecten van zaken lezen, met alle attributen
 
-### Zaken aanmaken
+### Zaken aanmaken (✓)
 
 **Label**
 

--- a/docs/_content/ontwikkelaars/apis/scopes.md
+++ b/docs/_content/ontwikkelaars/apis/scopes.md
@@ -102,10 +102,14 @@ Context-check: gebruiker heeft rol adviseur op de zaak in kwestie
     * mag lezen
     * mag toevoegen
 
-
 Challenges:
 
 * limiteer in DRC tot zaken waar NP adviseur is
+
+**Scopes nodig voor deze rol**:
+
+* `zds.scopes.zaken.lezen`
+* ...
 
 ### Behandelaar
 
@@ -148,6 +152,11 @@ Challenges:
 * beperken op basis van:
     * zaaktypes
     * zaak bij informatieobjecten
+
+**Scopes nodig voor deze rol**:
+
+* `zds.scopes.zaken.lezen`
+* ...
 
 ### Belanghebbende
 
@@ -204,6 +213,12 @@ Mogelijks subtypes:
     - mag toevoegen
     - mag lezen
 
+**Scopes nodig voor deze rol**:
+
+* `zds.scopes.zaken.aanmaken`
+* `zds.scopes.zaken.lezen` (?)
+* ...
+
 ### TODO
 
 - klantcontacter
@@ -233,13 +248,13 @@ Een `✓` betekent dat het in de referentieimplementatie gebouwd is.
     * ZaakType
     * StatusType
 
-### Zaken alles lezen
+### Zaken alles lezen (✓)
 
 Superset van `zds.scopes.zaken.lezen.openbaar`
 
 **Label**
 
-`zds.scopes.zaken.lezen.volledig`
+`zds.scopes.zaken.lezen`
 
 **Omvat**
 

--- a/docs/_content/ontwikkelaars/apis/scopes.md
+++ b/docs/_content/ontwikkelaars/apis/scopes.md
@@ -1,0 +1,75 @@
+# Scopes
+
+- vertrouwelijkheidsaanduiding
+- roltypen
+- AVG/privacy
+
+
+
+
+## Op basis van roltype:
+
+### `zds.scopes.roltype.adviseur`
+
+- zaak:
+    * lezen
+    * bewerken (toelichting)
+    * documenten aan zaak koppelen/bewerken
+    * objecten aan zaak koppelen/bewerken
+- klantcontact: (adviseur kan de klant contacteren)
+    * lezen
+    * registreren
+- besluit: nvt
+- informatieobjecten
+    * toevoegen
+
+### `zds.scopes.roltype.behandelaar`
+
+(eventueel behandelaar.intake, behandelaar.archivering, behandelaar.algemeen)
+
+- zaak
+    * alles, behalve:
+      - bewerken bronorganisatie, identificatie, zaaktype, registratiedatum, verantwoordelijkeOrganisatie,
+      - zetten laatste status (cfr. ZTC)
+
+- rest: bijna overal bij
+
+### `zds.scopes.roltype.belanghebbende`
+
+-> scope verfijning: privacy gevoelig of niet
+
+alleen lezen - heel beperkt
+
+- zaak: beperkt
+- informatieobjecten: afhankelijk van informatieobject vertrouwelijkheidniveau
+    * openbaar
+    * documenten waarbij belanghebbende afzender of bestemmeling is (TODO!)
+- besluiten: lezen (ev. afhankelijk van status)
+- klantcontacten: niets
+- zaakobjecten: afhankelijk van objectType
+- statussen: alles lezen
+- rollen: niets (of enkel zaakcoordinator)
+
+### `zds.scopes.roltype.beslisser`
+
+- besluit: aanmaken, lezen, bewerken
+- informatieobjecten: die bij besluit hangen
+- lezen (m.u.v. privacy)
+
+### `zds.scopes.roltype.initiator`
+
+- zaak: aanmaken
+- informatieobject: aanmaken
+- zaakinformatieobject: aanmaken
+-
+
+
+
+
+- initiator
+
+- klantcontacter
+
+- zaakcoordinator
+
+- mede-initiator

--- a/docs/_content/ontwikkelaars/apis/scopes.md
+++ b/docs/_content/ontwikkelaars/apis/scopes.md
@@ -1,83 +1,256 @@
 # Scopes
 
+Een scope in deze context is een label, bijvoorbeeld `zds.scopes.zaken.lezen`
+waar een bepaalde betekenis aan toegekend is. We gebruiken scopes om
+toegangsniveaus uit te drukken.
+
+Toegangscontrole in de APIs speelt op verschillende niveaus, waarbij met
+gegevens binnen de relevante data rekening moet gehouden worden.
+
+In de meest eenvoudige vorm kan een scope bepalen of je al dan niet toegang
+hebt tot een operatie binnen een resource. Een `alleen-lezen` scope zou je
+bijvoorbeeld toegang kunnen geven op `zaak_read` en `zaak_list`, maar toegang
+verbieden op `zaak_create`, `zaak_update` en `zaak_partial_update`.
+
+Zodra je scopes gaat onderkennen die meer businesslogica bevatten, zoals scopes
+koppelen aan de rol van een betrokkene, dan kan het zijn dat binnen collecties
+een andere (sub)set van records teruggegeven wordt doordat de scope dit inperkt.
+Een concreet voorbeeld hiervan kunnen zaakobjecten zijn die wel of niet
+privacygevoel zijn. Panden zouden bijvoorbeeld altijd teruggegeven kunnen
+worden (voor elke scope), maar gerelateerde natuurlijke personen zouden
+weggelaten kunnen worden voor een 'publieke' scope.
+
+Tot slot onderkennen we nog een niveau waarop gegevens ingehouden kunnen worden.
+Indien je een record mag lezen, dan kan het zijn dat je niet alle attributen
+binnen de record mag lezen. Bijvoorbeeld een klantcontactcentrummedewerker
+zou de voornaam + naam van de zaakinitiator mogen lezen, maar niet het BSN
+van deze persoon.
+
+De uitdaging bestaat erin om een set van scopes te definieren die beheersbaar
+is, maar toch toelaat om om te gaan met:
+
 - vertrouwelijkheidsaanduiding
 - roltypen
 - AVG/privacy
 
 ## Algemeen
-[bijdrage Arjan]<br>
-De mogelijkheden voor een gebruiker om gegevens van een object, zoals Zaak 1234 of Document Abcd, te mogen raadplegen en bewerken (cq. om een operatie op een - voorkomen in een - resource uit te voeren) hangen m.i. af van (minimaal) vier factoren.
-1) **_De categorie van het object_**. Bijvoorbeeld het zaaktype van een zaak, of een zaak al dan niet beeindigd is, etc. Zo zal een gebruiker veelal slechts zaken van bepaalde zaaktypen mogen raadplegen, of alleen onderhanden zaken. 
-2) **_De betrokkenheid van de gebruiker bij het object_**. Voor sommige objecten kan hiervan sprake zijn, bijvoorbeeld zaken (betrokkenen in rollen), veelal is hiervan voor andere objecten geen sprake (zoals zaaktype). Zo zijn de mogelijheden voor een gebruiker zijnde een Behandelaar van een Zaak anders dan een Initiator van een zaak en geheel anders dan een gebruiker die geen Rol heeft als Betrokkene bij de zaak. 
-3) **_De categorie van het gegeven (van het object)_** De gebruiker wil iets met een gegeven (of relatie) van het object (of met een groep gegevens). Met het ene gegeven zal hij/zij meer mogen dan met een ander gegeven. Het maakt bijvoorbeeld nogal uit of het om persoonsgegevens gaat of om archiveringsgegevens. 
-4) **_De mate van vertrouwelijkheid van het gegeven (van het object)_**. Ook al zou een gebruiker op grond van de voorgaande factoren het gegeven mogen raadplegen, dan nog kan het zijn dat hij/zij dat vanwege een bepaalde mate van vertrouwelijkheid toch niet mag.
+
+_Inzichten van Arjan_:
+
+De mogelijkheden voor een gebruiker om gegevens van een object - zoals
+'Zaak 1234' of 'Document Abcd' - te mogen raadplegen en/of bewerken hangen
+m.i. af van (minimaal) vier factoren:
+
+1. **_De categorie van het object_**.
+   Bijvoorbeeld het zaaktype van een zaak, of een zaak al dan niet beeindigd
+   is, etc. Zo zal een gebruiker veelal slechts zaken van bepaalde zaaktypen
+   mogen raadplegen, of alleen onderhanden zaken.
+
+2. **_De betrokkenheid van de gebruiker bij het object_**.
+   Voor sommige objecten kan hiervan sprake zijn, bijvoorbeeld zaken
+   (betrokkenen in rollen), veelal is hiervan voor andere objecten geen sprake
+   (zoals zaaktype). Zo zijn de mogelijheden voor een gebruiker zijnde een
+   'Behandelaar van een Zaak' anders dan een 'Initiator van een zaak' en geheel
+   anders dan een gebruiker die geen Rol heeft als Betrokkene bij de zaak.
+
+3. **_De categorie van het gegeven (van het object)_**.
+   De gebruiker wil iets met een gegeven (of relatie) van het object (of met
+   een groep gegevens). Met het ene gegeven zal hij/zij meer mogen dan met een
+   ander gegeven. Het maakt bijvoorbeeld nogal uit of het om persoonsgegevens
+   gaat of om archiveringsgegevens.
+
+4. **_De mate van vertrouwelijkheid van het gegeven (van het object)_**.
+   Ook al zou een gebruiker op grond van de voorgaande factoren het gegeven
+   mogen raadplegen, dan nog kan het zijn dat hij/zij dat vanwege een bepaalde
+   mate van vertrouwelijkheid toch niet mag.
 
 [uitwerken op de dwarsdoorsnedes van deze factoren, te beginnen met rollen versus vertrouwelijkheidniveau's]
 
-
 ## Op basis van roltype:
 
-### `zds.scopes.roltype.adviseur`
+### Adviseur
 
-- zaak:
-    * lezen
-    * bewerken (toelichting)
-    * documenten aan zaak koppelen/bewerken
-    * objecten aan zaak koppelen/bewerken
-- klantcontact: (adviseur kan de klant contacteren)
-    * lezen
-    * registreren
-- besluit: nvt
-- informatieobjecten
-    * toevoegen
+Context-check: gebruiker heeft rol adviseur op de zaak in kwestie
 
-### `zds.scopes.roltype.behandelaar`
+`GET /api/v1/rollen/?zaak=<url>&betrokkene=<url>&rolomschrijving=Adviseur`
 
-(eventueel behandelaar.intake, behandelaar.archivering, behandelaar.algemeen)
+**Resources**:
 
-- zaak
-    * alles, behalve:
-      - bewerken bronorganisatie, identificatie, zaaktype, registratiedatum, verantwoordelijkeOrganisatie,
-      - zetten laatste status (cfr. ZTC)
-
-- rest: bijna overal bij
-
-### `zds.scopes.roltype.belanghebbende`
-
--> scope verfijning: privacy gevoelig of niet
-
-alleen lezen - heel beperkt
-
-- zaak: beperkt
-- informatieobjecten: afhankelijk van informatieobject vertrouwelijkheidniveau
-    * openbaar
-    * documenten waarbij belanghebbende afzender of bestemmeling is (TODO!)
-- besluiten: lezen (ev. afhankelijk van status)
-- klantcontacten: niets
-- zaakobjecten: afhankelijk van objectType
-- statussen: alles lezen
-- rollen: niets (of enkel zaakcoordinator)
-
-### `zds.scopes.roltype.beslisser`
-
-- besluit: aanmaken, lezen, bewerken
-- informatieobjecten: die bij besluit hangen
-- lezen (m.u.v. privacy)
-
-### `zds.scopes.roltype.initiator`
-
-- zaak: aanmaken
-- informatieobject: aanmaken
-- zaakinformatieobject: aanmaken
--
+* Zaak:
+    * mag alle attributen lezen
+    * mag `toelichting` bewerken
+* ZaakInformatieObject:
+    * mag lezen
+    * mag toevoegen
+    * mag bewerken (`titel`, `beschrijving`)
+* EnkelvoudigInformatieObject:
+    * mag toevoegen
+    * mag lezen
+* ZaakObject:
+    * mag lezen
+    * mag toevoegen
+* Klantcontact:
+    * mag lezen
+    * mag toevoegen
 
 
+Challenges:
 
+* limiteer in DRC tot zaken waar NP adviseur is
 
-- initiator
+### Behandelaar
+
+Context-check: gebruiker heeft rol adviseur op de zaak in kwestie
+
+`GET /api/v1/rollen/?zaak=<url>&betrokkene=<url>&rolomschrijving=Behandelaar`
+
+Mogelijks subtypes:
+
+* intake
+* archivering
+* algemeen
+
+**Resources**:
+
+* Zaak:
+    * mag alle attributen lezen
+    * mag alle attributen bewerken, behalve:
+        - bronorganisatie
+        - identificatie
+        - zaaktype
+        - registratiedatum
+        - verantwoordelijkeOrganisatie
+* Status:
+    * mag alles lezen
+    * mag alle statussen behalve de laatste zetten
+* Zaaktype:
+    * mag alles lezen
+* Rol/Betrokkene:
+    * mag alles lezen
+* Klantcontact:
+    * mag alles lezen
+* ZaakInformatieObject:
+    * mag alles lezen
+* InformatieObject:
+    * mag alles lezen
+
+Challenges:
+
+* beperken op basis van:
+    * zaaktypes
+    * zaak bij informatieobjecten
+
+### Belanghebbende
+
+Mogelijks subtypes:
+
+* openbaar
+* privacy-gevoelig
+
+**Resources**:
+
+* Zaak:
+    * beperkt lezen:
+        - identificatie
+        - bronorganisatie
+        - omschrijving
+        - registratiedatum?
+        - zaaktype?
+        - ...?
+* InformatieObject:
+    * beperkt lezen: afhankelijk van informatieobject vertrouwelijkheidniveau
+        - openbaar
+        - documenten waarbij belanghebbende afzender of bestemmeling is
+* Besluit: lezen (ev. afhankelijk van status)
+* Klantcontact: niets
+* ZaakObject: afhankelijk van objectType
+* Status: alles lezen
+* Rol: niets (of enkel zaakcoordinator)
+
+### Beslisser
+
+**Resources**:
+
+* Besluit:
+    * mag toevoegen
+    * mag lezen
+    * mag bewerken
+* InformatieObject: (die aan besluit hangen)
+    * mag lezen
+    * mag toevoegen (?)
+    * mag bewerken (?)
+* Rest: mag lezen (m.u.v. privacy gevoelig)
+
+### Initiator
+
+**Resources**:
+
+* Zaak:
+    - mag toevoegen
+    - mag lezen
+* InformatieObject:
+    - mag toevoegen
+    - mag lezen
+* ZaakInformatieObject:
+    - mag toevoegen
+    - mag lezen
+
+### TODO
 
 - klantcontacter
 
 - zaakcoordinator
 
 - mede-initiator
+
+
+## Scope-definities
+
+Dit is heel erg WIP - we zoeken een goede balans!
+
+### Zaken openbaar lezen
+
+**Label**
+
+`zds.scopes.zaken.lezen.openbaar`
+
+**Omvat**
+
+* Toegang tot de volgende resources:
+    * Zaak
+    * Status
+    * ZaakType
+    * StatusType
+
+### Zaken alles lezen
+
+Superset van `zds.scopes.zaken.lezen.openbaar`
+
+**Label**
+
+`zds.scopes.zaken.lezen.volledig`
+
+**Omvat**
+
+* Kan alle attributen van zaken lezen, incl. privacy-gevoelig
+* Kan alle statussen van zaken lezen, met alle attributen
+* Kan alle zaakobjecten van zaken lezen, met alle attributen
+
+### Zaken aanmaken
+
+**Label**
+
+`zds.scopes.zaken.aanmaken`
+
+**Omvat**
+
+* `zaak_create`
+* `status_create` (indien nog geen status gezet is)
+* `rol_create`
+* `zaakobject_create`
+
+### Zaakdocumenten registreren
+
+**Label**
+
+`zds.scopes.zaakinformatieobjecten.aanmaken`

--- a/docs/_content/ontwikkelaars/apis/scopes.md
+++ b/docs/_content/ontwikkelaars/apis/scopes.md
@@ -1,3 +1,12 @@
+---
+title: "Scopes als autorisatiemechanisme"
+description: ""
+weight: 40
+menu:
+  docs:
+    parent: "developers"
+---
+
 # Scopes
 
 Een scope in deze context is een label, bijvoorbeeld `zds.scopes.zaken.lezen`

--- a/docs/_content/ontwikkelaars/apis/zrc.md
+++ b/docs/_content/ontwikkelaars/apis/zrc.md
@@ -18,6 +18,7 @@ medewerkerregistratiecomponent, etc.
 
 * [API-specificatie](https://ref.tst.vng.cloud/zrc/api/v1/schema/)
 * [Referentie implementatie](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent)
+* [Beschikbare scopes](https://ref.tst.vng.cloud/zrc/ref/scopes/)
 * Communiceren met dit component (client)
 * Zelf dit component implementeren (server)
 


### PR DESCRIPTION
# API specificatie aanpassing

Deze PR voegt een autorisatiemechanisme toe aan de API-spec en referentie-implementaties. Operaties worden al dan niet toegelaten op basis van claims van de client. Twee ondersteunde claims op dit moment zijn `scopes` en `zaaktypen`. Indien de client acties probeert uit te voeren die niet toegestaan zijn bij de aangeleverde claims, dan geeft de API een HTTP 403 foutmelding.

Er is een mechanisme afgesproken (JWT) om deze claims over te brengen van de client naar de API. Iedere client heeft in principe een eigen secret waarmee de claims digitaal ondertekend worden. Het secret is enkel bekend bij de client (taakapplicatie of een andere oplossing binnen de gemeente) en de API. De JWT headers worden gebruikt om af te leiden welk secret gebruikt wordt om de signature te valideren.

Deze opzet zorgt ervoor dat een arbitrair persoon (met technische kennis) binnen of buiten een organisatie niet zelf JWT kan maken met eender welke claims om zo data van de APIs te ontsluiten. Het is de bedoeling dat de gemeente zelf authenticatie inricht met als resultaat dat er validate JWT uitgegeven worden.

**Claims**

* De `scopes` claim geeft je wel/niet toegang tot bepaalde operaties in de API.
* De `zaaktypes` claim geeft je wel/niet toegang tot bepaalde records binnen operaties.

**Links**

* Zie: [User Story scopes](https://github.com/VNG-Realisatie/gemma-zaken/issues/424)
* Zie: [User Story implementatie](https://github.com/VNG-Realisatie/gemma-zaken/issues/425)

## ZRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/23) ✅
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/scopes/api-specificatie/zrc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Toevoegen van scopes:
    * `zds.scopes.zaken.lezen`: laat toe om zaken, statussen en zaakobjecten te lezen
    * `zds.scopes.zaken.aanmaken`: laat toe om een zaak toe te voegen, de eerste status bij een zaak te zetten, zaakobjecten aan te maken en rollen aan te maken
    * `zds.scopes.statussen.toevoegen`: laat toe om vervolgstatussen te zetten op zaken
* Toevoegen van documentatie van scopes: komt beschikbaar op https://ref.tst.vng.cloud/zrc/ref/scopes/, wat gericht is op developers om snel te zien welke scopes bestaan en wat ze betekenen
* Toevoeging van JWT-gebaseerde autorizatieschema in de API spec

**Kanttekeningen**

* hoe de nodige scopes nu in de API-spec gecommuniceerd worden... ik weet niet of dit correct is, maar ik zie ook niet meteen hoe het beter kan. Het komt wel door de OAS 3.0 validatie, en als het voor developers helder is, dan is het wat bij betreft 'wel goed'

## DRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/pull/22) ✅
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/scopes/api-specificatie/drc/openapi.yaml)


**Wijzigingen**
Er zijn (nog) geen aanpassingen aan de spec zelf.

* DRC authenticeert correct tegen ZRC en ZTC

## ZTC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/13) ✅
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/scopes/api-specificatie/ztc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Toevoegen van scopes:
    * `zds.scopes.zaaktypes.lezen`: laat toe om te lezen in het ZTC
* Toevoegen van documentatie van scopes: komt beschikbaar op 
  https://ref.tst.vng.cloud/ztc/ref/scopes/, wat gericht is op developers om 
  snel te zien welke scopes bestaan en wat ze betekenen
* Toevoeging van JWT-gebaseerde autorizatieschema in de API spec
* OAUTH tooling/stack verwijderd

## ZIT

[PR](https://github.com/VNG-Realisatie/gemma-zaken-test-integratie/pull/9)


# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
- [ ] Wijzigingen duidelijk omschreven en akkoord (@HenriKorver)
- [x] ~~Voldoet aan RGBZ of afwijkingen zijn akkoord (@ArjanKloosterboer)~~ n.v.t.?
- [x] ~~Voldoet aan GEMMA architectuur of afwijkingen zijn akkoord (@jgortmaker1)~~ n.v.t.
