### PR TITLE
Fixes #420 -- inputvalidatie op filter-parameters in querystring

### DIFF
--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: EUPL 1.2
   version: '1'
 security:
-- basic: []
+- JWT-Claims: []
 paths:
   /enkelvoudiginformatieobjecten:
     get:
@@ -255,6 +255,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ObjectInformatieObject'
+        '400':
+          description: ''
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
@@ -652,9 +658,10 @@ components:
             $ref: '#/components/schemas/ObjectInformatieObject'
       required: true
   securitySchemes:
-    basic:
+    JWT-Claims:
+      bearerFormat: JWT
+      scheme: bearer
       type: http
-      scheme: basic
   schemas:
     EnkelvoudigInformatieObject:
       required:

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -282,6 +282,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Rol'
+        '400':
+          description: ''
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
@@ -511,6 +517,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Status'
+        '400':
+          description: ''
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
@@ -991,6 +1003,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Zaak'
+        '400':
+          description: ''
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -809,6 +809,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RolType'
+        '400':
+          description: ''
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
@@ -1290,6 +1296,13 @@ components:
             format: uri
           readOnly: true
           uniqueItems: true
+        informatieobjecttypen:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
     Fout:
       required:
       - code
@@ -1489,6 +1502,13 @@ components:
             format: uri
           readOnly: true
           uniqueItems: true
+        besluittypen:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
     EigenschapSpecificatie:
       title: Specificatie
       required:
@@ -1646,6 +1666,71 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MogelijkeBetrokkene'
+    FieldValidationError:
+      required:
+      - name
+      - code
+      - reason
+      type: object
+      properties:
+        name:
+          title: Name
+          description: Naam van het veld met ongeldige gegevens
+          type: string
+          minLength: 1
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        reason:
+          title: Reason
+          description: Uitleg wat er precies fout is met de gegevens
+          type: string
+          minLength: 1
+    ValidatieFout:
+      required:
+      - code
+      - title
+      - status
+      - detail
+      - instance
+      - invalid-params
+      type: object
+      properties:
+        type:
+          title: Type
+          description: URI referentie naar het type fout, bedoeld voor developers
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: Extra informatie bij de fout, indien beschikbaar
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1
+        invalid-params:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldValidationError'
     StatusType:
       required:
       - omschrijving

--- a/docs/_content/ontwikkelaars/algemeen/standaard.md
+++ b/docs/_content/ontwikkelaars/algemeen/standaard.md
@@ -20,6 +20,7 @@ tussen registraties en consumers die van de API's gebruik maken.
 - [Definities](#definities)
 - [Gegevensformaten](#gegevensformaten)
 - [Autorisatie](#autorisatie)
+- [Filter parameters](#filter-parameters)
 - [Zaakregistratiecomponent](#zaakregistratiecomponent)
     - [OpenAPI specificatie](#openapi-specificatie)
     - [Run-time gedrag](#run-time-gedrag)
@@ -118,6 +119,18 @@ Voorbeeld van een payload:
     }
 }
 ```
+
+## Filter parameters
+
+Componenten ondersteunen het filteren van gegevens op basis van parameters in
+de querystring. Deze parameters MOETEN gevalideerd worden op het juiste
+formaat, net zoals inputvalidatie plaatsvindt bij een `create` of `update`.
+
+Indien de validatie faalt, dan MOET de API antwoorden met een HTTP 400
+foutbericht, waarbij de `invalid-params` key meer informatie bevat over de fout.
+
+Indien een parameter wordt toegepast die niet in de OAS van de betreffende API
+staat, dan MOET de API antwoorden met een HTTP 400 foutbericht.
 
 ## Zaakregistratiecomponent
 


### PR DESCRIPTION
# API specificatie aanpassing

Bij het filteren op endpoints kunnen twee problemen zich voordoen, met hetzelfde
resultaat: de collectie van gegevens wordt niet gefilterd zoals verwacht wordt:

* een filter parameter heeft een ongeldig formaat (voorbeeld een RSIN/BSN dat 
  niet aan de elf-proef voldoet)
* een filter parameter is niet bekend (typfout, parameter niet geimplementeerd)

Deze PR/spec geeft aan dat endpoints validatiefouten moeten teruggeven bij foute
filter-input.

* Zie: [User Story](https://github.com/VNG-Realisatie/gemma-zaken/issues/420)

## ZRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/31)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-420-filter-input-validation/api-specificatie/zrc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Op de `zaken`, `statussen` en `rollen` endpoints is HTTP 400 als mogelijke
  response toegevoegd.
* Referentieimplementatie geeft foutresponse bij invalidate querystring 
  parameters.
* Validatie dat parameters eruit zien als URL/RSIN waar van toepassing.

## DRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/pull/26)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-420-filter-input-validation/api-specificatie/drc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Op de `objectinformatieobjecten` endpoint is HTTP 400 als mogelijke response 
  toegevoegd.
* Referentieimplementatie geeft foutresponse bij invalidate querystring 
  parameters.
* Validatie dat parameters eruit zien als URL

## ZTC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/21)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-420-filter-input-validation/api-specificatie/ztc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Op de `roltypen` endpoint is HTTP 400 als mogelijke response toegevoegd.
* Foutformaten opgenomen in API-spec

## BRC

Geen aanpassingen - er zijn nog geen filters.

# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
- [ ] Wijzigingen duidelijk omschreven en akkoord (@HenriKorver)
- [x] ~~Voldoet aan RGBZ of afwijkingen zijn akkoord~~ n.v.t.
- [x] ~~Voldoet aan GEMMA architectuur of afwijkingen zijn akkoord~~ n.v.t.
