### PR TITLE
Fix kapotte link naar OpenAPI 3.0 specs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -22,3 +22,4 @@ FROM nginx:stable-alpine
 COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=build /app/_site /usr/share/nginx/html
+COPY ./api-specificatie /usr/share/nginx/html

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -149,7 +149,7 @@ Zaakregistratiecomponenten (ZRC) MOETEN aan twee aspecten voldoen:
 
 ### OpenAPI specificatie
 
-Alle operaties beschreven in [`openapi.yaml`](./api-specificatie/zrc/openapi.yaml)
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/zrc/openapi.yaml)
 MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de
 referentie-implementatie van het ZRC.
 
@@ -232,7 +232,7 @@ documentregistratiecomponentsen (DRC) MOETEN aan twee aspecten voldoen:
 
 ### OpenAPI specificatie
 
-Alle operaties beschreven in [`openapi.yaml`](./api-specificatie/drc/openapi.yaml)
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/drc/openapi.yaml)
 MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de referentie-
 implementatie van het DRC.
 
@@ -348,7 +348,7 @@ Besluitregistratiecomponenten (BRC) MOETEN aan twee aspecten voldoen:
 
 ### OpenAPI specificatie
 
-Alle operaties beschreven in [`openapi.yaml`](./api-specificatie/brc/openapi.yaml)
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/brc/openapi.yaml)
 MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de
 referentie-implementatie van het BRC.
 

--- a/docs/release-docker-image.sh
+++ b/docs/release-docker-image.sh
@@ -12,9 +12,11 @@ git_branch=$(git branch --contains HEAD 2>/dev/null)
 
 build_image() {
     tag=$1
+    cp -r ../api-specificatie ./api-specificatie
     docker build \
         -t ${CONTAINER_REPO}:$tag \
         -f Dockerfile .
+    rm -rf ./api-specificatie
 }
 
 get_release_tag() {


### PR DESCRIPTION
1. Fixt de relatieve link in Github
2. Zorgt ervoor dat de API-specificatie zelf ook in de docker image gepubliceerd wordt, zodat de gehoste documentatie ook correcte links heeft.

Op deze manier houden we de semantische layout in de repository, maar nog steeds een andere, logische structuur in de gepubliceerde documentatie.