### PR TITLE
Fixes #344 -- voeg resultaattype toe

### DIFF
--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -2031,6 +2031,308 @@ paths:
       schema:
         type: string
         format: uuid
+  /resultaattypen:
+    get:
+      operationId: resultaattype_list
+      description: Een verzameling van RESULTAATTYPEn.
+      parameters:
+      - name: zaaktype
+        in: query
+        description: URL to the related resource
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: pagina
+        in: query
+        description: A page number within the paginated result set.
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                required:
+                - count
+                - results
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                  previous:
+                    type: string
+                    format: uri
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ResultaatType'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaattypen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
+    parameters: []
+  /resultaattypen/{uuid}:
+    get:
+      operationId: resultaattype_read
+      description: 'Het betreft de indeling of groepering van resultaten van zaken
+        van hetzelfde
+
+        ZAAKTYPE naar hun aard, zoals ''verleend'', ''geweigerd'', ''verwerkt'', etc.'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResultaatType'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaattypen
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaaktypes.lezen
+    parameters:
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
   /zaaktype-informatieobjecttypen:
     get:
       operationId: zaakinformatieobjecttype_list
@@ -2498,6 +2800,7 @@ components:
           description: Het aantal dagen, gerekend vanaf de verzend- of publicatiedatum,
             waarbinnen verweer tegen een besluit van het besluittype mogelijk is.
           type: string
+          format: duration
         publicatieIndicatie:
           title: Publicatie indicatie
           description: Aanduiding of BESLUITen van dit BESLUITTYPE gepubliceerd moeten
@@ -2513,6 +2816,7 @@ components:
           description: Het aantal dagen, gerekend vanaf de verzend- of publicatiedatum,
             dat BESLUITen van dit BESLUITTYPE gepubliceerd moeten blijven.
           type: string
+          format: duration
         toelichting:
           title: Toelichting
           description: Een eventuele toelichting op dit BESLUITTYPE.
@@ -2707,12 +3011,14 @@ components:
           description: De periode waarbinnen volgens wet- en regelgeving een ZAAK
             van het ZAAKTYPE afgerond dient te zijn, in kalenderdagen.
           type: string
+          format: duration
         servicenorm:
           title: Servicenorm
           description: De periode waarbinnen verwacht wordt dat een ZAAK van het ZAAKTYPE
             afgerond wordt conform de geldende servicenormen van de zaakbehandelende
             organisatie(s).
           type: string
+          format: duration
         opschortingEnAanhoudingMogelijk:
           title: Opschorting/aanhouding mogelijk
           description: Aanduiding die aangeeft of ZAAKen van dit mogelijk ZAAKTYPE
@@ -2729,6 +3035,7 @@ components:
             ZAAKen van dit ZAAKTYPE kan worden verlengd. Mag alleen een waarde bevatten
             als verlenging mogelijk is.
           type: string
+          format: duration
         trefwoorden:
           description: Een trefwoord waarmee ZAAKen van het ZAAKTYPE kunnen worden
             gekarakteriseerd.
@@ -2781,6 +3088,13 @@ components:
           type: string
           format: uri
         statustypen:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
+        resultaattypen:
           type: array
           items:
             type: string
@@ -3093,6 +3407,151 @@ components:
             is afgeleid uit alle STATUSTYPEn van dit ZAAKTYPE met het hoogste volgnummer.
           type: boolean
           readOnly: true
+    BrondatumArchiefprocedure:
+      title: Brondatum archiefprocedure
+      description: Specificatie voor het bepalen van de brondatum voor de start van
+        de Archiefactietermijn (=brondatum) van het zaakdossier.
+      required:
+      - afleidingswijze
+      - procestermijn
+      type: object
+      properties:
+        afleidingswijze:
+          title: Afleidingswijze brondatum
+          description: Wijze van bepalen van de brondatum.
+          type: string
+          enum:
+          - afgehandeld
+          - ander_datumkenmerk
+          - eigenschap
+          - gerelateerde_zaak
+          - hoofdzaak
+          - ingangsdatum_besluit
+          - termijn
+          - vervaldatum_besluit
+          - zaakobject
+        datumkenmerk:
+          title: Datumkenmerk
+          description: Naam van de attribuutsoort van het procesobject dat bepalend
+            is voor het einde van de procestermijn.
+          type: string
+          maxLength: 80
+        einddatumBekend:
+          title: Einddatum bekend
+          description: Indicatie dat de einddatum van het procesobject gedurende de
+            uitvoering van de zaak bekend moet worden. Indien deze nog niet bekend
+            is en deze waarde staat op `true`, dan kan de zaak (nog) niet afgesloten
+            worden.
+          type: boolean
+        objecttype:
+          title: Objecttype
+          description: Het soort object in de registratie dat het procesobject representeert.
+          type: string
+          enum:
+          - VerblijfsObject
+          - MeldingOpenbareRuimte
+          - InzageVerzoek
+        registratie:
+          title: Registratie
+          description: De naam van de registratie waarvan het procesobject deel uit
+            maakt.
+          type: string
+          maxLength: 80
+        procestermijn:
+          title: Procestermijn
+          description: De periode dat het zaakdossier na afronding van de zaak actief
+            gebruikt en/of geraadpleegd wordt ter ondersteuning van de taakuitoefening
+            van de organisatie. Enkel relevant indien de afleidingswijze 'termijn'
+            is.
+          type: string
+          format: duration
+    ResultaatType:
+      required:
+      - omschrijving
+      - resultaattypeomschrijving
+      - selectielijstklasse
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaaktype:
+          title: is van
+          type: string
+          format: uri
+          readOnly: true
+        omschrijving:
+          title: Omschrijving
+          description: Omschrijving van de aard van resultaten van het RESULTAATTYPE.
+          type: string
+          maxLength: 20
+          minLength: 1
+        resultaattypeomschrijving:
+          title: Resultaattypeomschrijving
+          description: Algemeen gehanteerde omschrijving van de aard van resultaten
+            van het RESULTAATTYPE. Dit moet een URL-referentie zijn naar de referenlijst
+            van generieke resultaattypeomschrijvingen. Im ImZTC heet dit 'omschrijving
+            generiek'
+          type: string
+          format: uri
+          maxLength: 1000
+          minLength: 1
+        omschrijvingGeneriek:
+          title: Omschrijving generiek
+          description: Waarde van de omschrijving-generiek referentie (attribuut `omschrijving`)
+          type: string
+          readOnly: true
+          minLength: 1
+        selectielijstklasse:
+          title: Selectielijstklasse
+          description: Verwijzing naar de, voor het archiefregime bij het RESULTAATTYPE
+            relevante, categorie in de Selectielijst Archiefbescheiden van de voor
+            het ZAAKTYPE verantwoordelijke overheidsorganisatie. Dit is een URL-referentie
+            naar een resultaat uit de selectielijst API
+          type: string
+          format: uri
+          maxLength: 1000
+          minLength: 1
+        toelichting:
+          title: Toelichting
+          description: Een toelichting op dit RESULTAATTYPE en het belang hiervan
+            voor ZAAKen waarin een resultaat van dit RESULTAATTYPE wordt geselecteerd.
+          type: string
+        archiefnominatie:
+          title: Archiefnominatie
+          description: 'Aanduiding die aangeeft of ZAAKen met een resultaat van dit
+            RESULTAATTYPE blijvend moeten worden bewaard of (op termijn) moeten worden
+            vernietigd. Indien niet expliciet opgegeven wordt dit gevuld vanuit de
+            selectielijst.
+
+
+            De mapping van waarden naar weergave is als volgt:
+
+
+            * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum
+            overgedragen worden naar een archiefbewaarplaats.
+
+            * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd
+            worden.'
+          type: string
+          enum:
+          - blijvend_bewaren
+          - vernietigen
+        archiefactietermijn:
+          title: Archiefactietermijn
+          description: De termijn, na het vervallen van het bedrjfsvoeringsbelang,
+            waarna het zaakdossier (de ZAAK met alle bijbehorende INFORMATIEOBJECTen)
+            van een ZAAK met een resultaat van dit RESULTAATTYPE vernietigd of overgebracht
+            (naar een archiefbewaarplaats) moet worden. Voor te vernietigen dossiers
+            betreft het de in die Selectielijst genoemde bewaartermjn. Voor blijvend
+            te bewaren zaakdossiers betreft het de termijn vanaf afronding van de
+            zaak tot overbrenging (de procestermijn is dan nihil).
+          type: string
+          format: duration
+        brondatumArchiefprocedure:
+          $ref: '#/components/schemas/BrondatumArchiefprocedure'
     ZaakTypeInformatieObjectType:
       required:
       - volgnummer

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -561,7 +561,8 @@ de `Procestype` resource in de selectielijst-API zijn, indien ingevuld.
 Het attribuut `Resultaattype.resultaattypeomschrijving` MOET een URL-verwijzing
 naar de `Resultaattypeomschrijving` resource in de referentielijsten-API zijn.
 Het ZTC MOET de waarde van `Resultaattypeomschrijving.omschrijving` ontsluiten
-als alleen-lezen attribuut `Resultaattype.omschrijvingGeneriek`.
+(uit de selectielijst) als alleen-lezen attribuut
+`Resultaattype.omschrijvingGeneriek`.
 
 Het attribuut `Resultaattype.selectielijstklasse` MOET een URL-verwijzing zijn
 naar de `Resultaat` resource in de selectielijst-API. Tevens MOET dit
@@ -579,8 +580,8 @@ selectielijstklasse.
 **`Resultaattype.brondatumArchiefprocedure`**
 
 Het groepattribuut `Resultaattype.brondatumArchiefprocedure` parametriseert
-het betalen van de `brondatum` voor de `archiefactietermijn` van een zaak. Deze
-parametrisering is aan validatieregels onderheving:
+het bepalen van de `brondatum` voor de `archiefactietermijn` van een zaak. Deze
+parametrisering is aan validatieregels onderhevig:
 
 * `Resultaattype.brondatumArchiefprocedure.afleidingswijze`:
     * afleidingswijze MOET `afgehandeld` zijn indien de selectielijstklasse

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -31,6 +31,9 @@ tussen registraties en consumers die van de API's gebruik maken.
 - [Besluitregistratiecomponent](#besluitregistratiecomponent)
   - [OpenAPI specificatie](#openapi-specificatie-2)
   - [Run-time gedrag](#run-time-gedrag-2)
+- [Zaaktypecatalogus](#zaaktypecatalogus)
+    - [OpenAPI specificatie](#openapi-specificatie-3)
+    - [Run-time gedrag](#run-time-gedrag-3)
 
 ## Definities
 
@@ -515,3 +518,95 @@ status code, MOET het BRC antwoorden met een `HTTP 400` foutbericht.
 Er MOET gevalideerd worden dat de combinatie `besluit` en `informatieobject`
 niet eerder voorkomt. Indien deze al bestaat, dan MOET het BRC antwoorden met
 een `HTTP 400` foutbericht.
+
+## Zaaktypecatalogus
+
+Zaaktypecatalogi (ZTC) MOETEN aan twee aspecten voldoen:
+
+* de ZTC `openapi.yaml` MOET volledig geïmplementeerd zijn
+
+* het run-time gedrag beschreven in deze standaard MOET correct geïmplementeerd
+  zijn.
+
+Het ZTC haalt informatie uit selectielijsten en de Gemeentelijke Selectielijst
+2017. Deze gegevens worden ontsloten in de
+[VNG-referentielijsten-API](https://ref.tst.vng.cloud/referentielijsten/). Op
+korte termijn zal deze API gesplitst worden in een referentielijsten-API en de
+selectielijst-API (waar deze nu nog 1 API is)
+[#3 on Github](https://github.com/VNG-Realisatie/VNG-referentielijsten/issues/3).
+
+### OpenAPI specificatie
+
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/ztc/openapi.yaml)
+MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de
+referentie-implementatie van het ZTC.
+
+Het is NIET TOEGESTAAN om gebruik te maken van operaties die niet beschreven
+staan in deze OAS spec, of om uitbreidingen op operaties in welke vorm dan ook
+toe te voegen.
+
+### Run-time gedrag
+
+Bepaalde gedrageningen kunnen niet in een OAS spec uitgedrukt worden omdat ze
+businesslogica bevatten. Deze gedragingen zijn hieronder beschreven en MOETEN
+zoals beschreven geïmplementeerd worden.
+
+#### Valideren van `Zaaktype`
+
+Het attribuut `Zaaktype.selectielijstProcestype` MOET een URL-verwijzing naar
+de `Procestype` resource in de selectielijst-API zijn, indien ingevuld.
+
+#### Valideren van `Resultaattype`
+
+Het attribuut `Resultaattype.resultaattypeomschrijving` MOET een URL-verwijzing
+naar de `Resultaattypeomschrijving` resource in de referentielijsten-API zijn.
+Het ZTC MOET de waarde van `Resultaattypeomschrijving.omschrijving` ontsluiten
+als alleen-lezen attribuut `Resultaattype.omschrijvingGeneriek`.
+
+Het attribuut `Resultaattype.selectielijstklasse` MOET een URL-verwijzing zijn
+naar de `Resultaat` resource in de selectielijst-API. Tevens MOET dit
+`resultaat` horen bij het `procestype` geconfigureerd op
+`Resultaattype.zaaktype.selectielijstProcestype`.
+
+Indien `Resultaattype.archiefnominatie` niet expliciet opgegeven wordt, dan
+MOET het ZTC deze afleiden uit `Resultaat.waardering` van de
+selectielijstklasse.
+
+Indien `Resultaattype.archiefactietermijn` niet expliciet opgegeven wordt, dan
+MOET het ZTC deze afleiding uit `Resultaat.bewaartermijn` van de
+selectielijstklasse.
+
+**`Resultaattype.brondatumArchiefprocedure`**
+
+Het groepattribuut `Resultaattype.brondatumArchiefprocedure` parametriseert
+het betalen van de `brondatum` voor de `archiefactietermijn` van een zaak. Deze
+parametrisering is aan validatieregels onderheving:
+
+* `Resultaattype.brondatumArchiefprocedure.afleidingswijze`:
+    * afleidingswijze MOET `afgehandeld` zijn indien de selectielijstklasse
+      als procestermijn `nihil` heeft en vice versa
+    * afleidingswijze MOET `termijn` zijn indien de selectielijstklasse
+      als procestermijn `ingeschatte_bestaansduur_procesobject` heeft en vice
+      versa
+
+* `Resultaattype.brondatumArchiefprocedure.datumkenmerk`
+    * MOET een waarde hebben als de afleidingswijze `eigenschap`, `zaakobject`
+      of `ander_datumkenmerk` is
+    * MAG GEEN waarde hebben in de andere gevallen
+
+* `Resultaattype.brondatumArchiefprocedure.einddatumBekend`
+    * MAG GEEN waarde hebben indien de afleidingswijze `afgehandeld` of
+      `termijn` is
+
+* `Resultaattype.brondatumArchiefprocedure.objecttype`
+    * MOET een waarde hebben als de afleidingswijze `zaakobject`
+      of `ander_datumkenmerk` is
+    * MAG GEEN waarde hebben in de andere gevallen
+
+* `Resultaattype.brondatumArchiefprocedure.registratie`
+    * MOET een waarde hebben indien de afleidingswijze `ander_datumkenmerk` is
+    * MAG GEEN waarde hebben in de andere gevallen
+
+* `Resultaattype.brondatumArchiefprocedure.procestermijn`
+    * MOET een waarde hebben indien de afleidingswijze `termijn` is
+    * MAG GEEN waarde hebben in de andere gevallen


### PR DESCRIPTION
# API specificatie aanpassing

Deze PR voegt de `Resultaattype` resource toe aan het ZTC met support voor
archiveringsparameters.

* Zie: [User Story](https://github.com/VNG-Realisatie/gemma-zaken/issues/344)
* Zie: [Archiveren voor dummies](https://github.com/VNG-Realisatie/gemma-zaken/blob/master/docs/_content/ontwikkelaars/algemeen/archiveren.md)

## ZTC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/29)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-344-ztc-archiefparameters/api-specificatie/ztc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* added read-only `ResultaatType` resource to API
* added `format: duration` to duration-attributes
* added `Zaaktype.resultaattypen` list of URLs
* added `brondatumArchiefProcedure` as part of `ResultaatType` resource
  * contains strategy on how to determine `brondatum`
  * validated against Gemeentelijke Selectielijst 2017 where possible
* ResultaatType is linked to GS 2017 + validations implemented

**Kanttekeningen**

* URL-referenties naar Gemeentelijke Selectielijst 2017 API & referentielijsten
  kunnen wijzen naar https://ref.tst.vng.cloud/referentielijsten/
* parametrisering van `brondatumArchiefProcedure` is erg complex en beschreven
  in `standaard.md`
* `Resultaattype.omschrijvingGeneriek` in ImZTC is alleen-lezen ontsloten, configuratie gebeurt via `Resultaattype.resultaattypeomschrijving` (URL referentie naar referentielijst-API)
* `Resultaattype.selectielijstklasse` is niet een nummer uit de selectielijst, maar URL-referentie naar het resultaat in de selectielijst-API
* `archiefnominatie` en `archiefactietermijn` worden afgeleid uit selectielijst tenzij expliciet opgegeven
* `procestermijn` is in het groepattribuut `brondatumArchiefprocedure` gestopt, en mag enkel gevuld zijn als de afleidingswijze `termijn` is, wat ook weer volgt uit de link met de selectielijst

# Review checklist

Aftikken van reviewelementen

- [ ] Build slaagt
- [ ] Wijzigingen duidelijk omschreven en akkoord (@michielverhoef)
- [ ] Voldoet aan RGBZ of afwijkingen zijn akkoord (@Remkodehaas )
