### PR TITLE
Fixes #345, fixes #348, fixes #349 -- archivering parameters, filters & destroy operaties

### DIFF
--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -1565,6 +1565,129 @@ paths:
       - besluiten
       requestBody:
         $ref: '#/components/requestBodies/Besluit'
+    delete:
+      operationId: besluit_delete
+      description: Verwijdert een BESLUIT, samen met alle gerelateerde resources binnen
+        deze API.
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - besluiten
     parameters:
     - name: uuid
       in: path

--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -748,6 +748,129 @@ paths:
       - enkelvoudiginformatieobjecten
       requestBody:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectData'
+    delete:
+      operationId: enkelvoudiginformatieobject_delete
+      description: Verwijdert een ENKELVOUDIG INFORMATIEOBJECT, samen met alle gerelateerde
+        resources binnen deze API.
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - enkelvoudiginformatieobjecten
     parameters:
     - name: uuid
       in: path
@@ -2358,6 +2481,128 @@ paths:
       - objectinformatieobjecten
       requestBody:
         $ref: '#/components/requestBodies/ObjectInformatieObject'
+    delete:
+      operationId: objectinformatieobject_delete
+      description: Verwijdert de relatie tussen OBJECT en INFORMATIEOBJECT.
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - objectinformatieobjecten
     parameters:
     - name: uuid
       in: path
@@ -2482,8 +2727,8 @@ components:
         bronorganisatie:
           title: Bronorganisatie
           description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie\
-            \ die het informatieobject heeft gecre\xEBerd of heeft ontvangen en als\
-            \ eerste in een samenwerkingsketen heeft vastgelegd."
+            \ die het informatieobject heeft gecre\xC3\xABerd of heeft ontvangen en\
+            \ als eerste in een samenwerkingsketen heeft vastgelegd."
           type: string
           maxLength: 9
           minLength: 1
@@ -2515,7 +2760,7 @@ components:
         auteur:
           title: Auteur
           description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
-            \ is voor het cre\xEBren van de inhoud van het INFORMATIEOBJECT."
+            \ is voor het cre\xC3\xABren van de inhoud van het INFORMATIEOBJECT."
           type: string
           maxLength: 200
           minLength: 1
@@ -3161,8 +3406,8 @@ components:
         bronorganisatie:
           title: Bronorganisatie
           description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie\
-            \ die het informatieobject heeft gecre\xEBerd of heeft ontvangen en als\
-            \ eerste in een samenwerkingsketen heeft vastgelegd."
+            \ die het informatieobject heeft gecre\xC3\xABerd of heeft ontvangen en\
+            \ als eerste in een samenwerkingsketen heeft vastgelegd."
           type: string
           maxLength: 9
           minLength: 1
@@ -3194,7 +3439,7 @@ components:
         auteur:
           title: Auteur
           description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
-            \ is voor het cre\xEBren van de inhoud van het INFORMATIEOBJECT."
+            \ is voor het cre\xC3\xABren van de inhoud van het INFORMATIEOBJECT."
           type: string
           maxLength: 200
           minLength: 1

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -433,6 +433,865 @@ paths:
       schema:
         type: string
         format: uuid
+  /resultaten:
+    get:
+      operationId: resultaat_list
+      description: 'Geef een lijst van RESULTAATen van ZAAKen.
+
+
+        Optioneel kan je de queryparameters gebruiken om de resultaten te
+
+        filteren.'
+      parameters:
+      - name: zaak
+        in: query
+        description: URL to the related resource
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: resultaatType
+        in: query
+        description: ''
+        required: false
+        schema:
+          type: string
+          format: uri
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resultaat'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
+    post:
+      operationId: resultaat_create
+      description: 'Voeg een RESULTAAT voor een ZAAK toe.
+
+
+        **Er wordt gevalideerd op**
+
+        - geldigheid URL naar de ZAAK
+
+        - geldigheid URL naar het RESULTAATTYPE'
+      responses:
+        '201':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/Resultaat'
+    parameters: []
+  /resultaten/{uuid}:
+    get:
+      operationId: resultaat_read
+      description: Haal de details van het RESULTAAT op.
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.lezen
+    put:
+      operationId: resultaat_update
+      description: 'Wijzig het RESULTAAT van een ZAAK.
+
+
+        **Er wordt gevalideerd op**
+
+        - geldigheid URL naar de ZAAK
+
+        - geldigheid URL naar het RESULTAATTYPE'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/Resultaat'
+    patch:
+      operationId: resultaat_partial_update
+      description: 'Wijzig het RESULTAAT van een ZAAK.
+
+
+        **Er wordt gevalideerd op**
+
+        - geldigheid URL naar de ZAAK
+
+        - geldigheid URL naar het RESULTAATTYPE'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/Resultaat'
+    delete:
+      operationId: resultaat_delete
+      description: Verwijder het RESULTAAT van een ZAAK.
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - resultaten
+      security:
+      - JWT-Claims:
+        - zds.scopes.zaken.bijwerken
+    parameters:
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
   /rollen:
     get:
       operationId: rol_list
@@ -1035,7 +1894,7 @@ paths:
     post:
       operationId: status_create
       description: "Voeg een nieuwe STATUS voor een ZAAK toe.\n\n**Er wordt gevalideerd\
-        \ op**\n- geldigheid URL naar de zaak\n- geldigheid URL naar het STATUSTYPE\n\
+        \ op**\n- geldigheid URL naar de ZAAK\n- geldigheid URL naar het STATUSTYPE\n\
         - indien het de eindstatus betreft, dan moet het attribuut\n  `indicatieGebruiksrecht`\
         \ gezet zijn op alle informatieobjecten die aan\n  de zaak gerelateerd zijn\n\
         \n**Opmerkingen**\n- Indien het statustype de eindstatus is (volgens het ZTC),\
@@ -1720,7 +2579,7 @@ paths:
       operationId: zaak_list
       description: "Geef een lijst van ZAAKen.\n\nOptioneel kan je de queryparameters\
         \ gebruiken om zaken te filteren.\n\n**Opmerkingen**\n- je krijgt enkel zaken\
-        \ terug van de zaaktypes die in het\n  autorisatie-JWT vervat zitten."
+        \ terug van de zaaktypes die in het autorisatie-JWT\n  vervat zitten."
       parameters:
       - name: identificatie
         in: query
@@ -1744,6 +2603,67 @@ paths:
         schema:
           type: string
           format: uri
+      - name: archiefnominatie
+        in: query
+        description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+          termijn vernietigd moet worden.
+        required: false
+        schema:
+          type: string
+          enum:
+          - blijvend_bewaren
+          - vernietigen
+      - name: archiefnominatie__in
+        in: query
+        description: Multiple values may be separated by commas.
+        required: false
+        schema:
+          type: string
+      - name: archiefactiedatum
+        in: query
+        description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+          worden dan wel overgebracht moet worden naar een archiefbewaarplaats. Wordt
+          automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT aan
+          deze ZAAK indien nog leeg.
+        required: false
+        schema:
+          type: string
+      - name: archiefactiedatum__lt
+        in: query
+        description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+          worden dan wel overgebracht moet worden naar een archiefbewaarplaats. Wordt
+          automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT aan
+          deze ZAAK indien nog leeg.
+        required: false
+        schema:
+          type: string
+      - name: archiefactiedatum__gt
+        in: query
+        description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+          worden dan wel overgebracht moet worden naar een archiefbewaarplaats. Wordt
+          automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT aan
+          deze ZAAK indien nog leeg.
+        required: false
+        schema:
+          type: string
+      - name: archiefstatus
+        in: query
+        description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+          termijn vernietigd moet worden.
+        required: false
+        schema:
+          type: string
+          enum:
+          - nog_te_archiveren
+          - gearchiveerd
+          - gearchiveerd_procestermijn_onbekend
+          - overgedragen
+      - name: archiefstatus__in
+        in: query
+        description: Multiple values may be separated by commas.
+        required: false
+        schema:
+          type: string
       - name: Accept-Crs
         in: header
         description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
@@ -1914,22 +2834,17 @@ paths:
         - zds.scopes.zaken.lezen
     post:
       operationId: zaak_create
-      description: 'Maak een ZAAK aan.
-
-
-        Indien geen identificatie gegeven is, dan wordt deze automatisch
-
-        gegenereerd. De identificatie moet uniek zijn binnen de bronorganisatie.
-
-
-        Er wordt gevalideerd op:
-
-        - geldigheid URL naar zaaktype
-
-        - laatsteBetaaldatum mag niet in de toekomst liggen
-
-        - laatsteBetaaldatum nag niet gezet worden als de betalingsindicatie "nvt"
-        is'
+      description: "Maak een ZAAK aan.\n\nIndien geen identificatie gegeven is, dan\
+        \ wordt deze automatisch\ngegenereerd. De identificatie moet uniek zijn binnen\
+        \ de bronorganisatie.\n\n**Er wordt gevalideerd op**:\n- `zaaktype` moet een\
+        \ geldige URL zijn.\n- `laatsteBetaaldatum` mag niet in de toekomst liggen.\n\
+        - `laatsteBetaaldatum` mag niet gezet worden als de betalingsindicatie\n \
+        \ \"nvt\" is.\n- `archiefnominatie` moet een waarde hebben indien `archiefstatus`\
+        \ niet de\n  waarde \"nog_te_archiveren\" heeft.\n- `archiefactiedatum` moet\
+        \ een waarde hebben indien `archiefstatus` niet de\n  waarde \"nog_te_archiveren\"\
+        \ heeft.\n- `archiefstatus` kan alleen een waarde anders dan \"nog_te_archiveren\"\
+        \n  hebben indien van alle gerelateeerde INFORMATIEOBJECTen het attribuut\n\
+        \  `status` de waarde \"gearchiveerd\" heeft."
       parameters:
       - name: Accept-Crs
         in: header
@@ -2455,14 +3370,19 @@ paths:
         - zds.scopes.zaken.lezen
     put:
       operationId: zaak_update
-      description: "Werk een zaak bij.\n\n**Er wordt gevalideerd op**\n- geldigheid\
-        \ URL naar zaaktype\n- laatsteBetaaldatum mag niet in de toekomst liggen\n\
-        - laatsteBetaaldatum nag niet gezet worden als de betalingsindicatie \"nvt\"\
-        \ is\n\n**Opmerkingen**\n- je krijgt enkel zaken terug van de zaaktypes die\
-        \ in het autorisatie-JWT\n  vervat zitten\n- zaaktype zal in de toekomst niet-wijzigbaar\
-        \ gemaakt worden.\n- indien een zaak heropend moet worden, doe dit dan door\
-        \ een nieuwe status\n  toe te voegen die NIET de eindstatus is. Zie de `Status`\
-        \ resource."
+      description: "Werk een zaak bij.\n\n**Er wordt gevalideerd op**\n- `zaaktype`\
+        \ moet een geldige URL zijn.\n- `laatsteBetaaldatum` mag niet in de toekomst\
+        \ liggen.\n- `laatsteBetaaldatum` mag niet gezet worden als de betalingsindicatie\n\
+        \  \"nvt\" is.\n- `archiefnominatie` moet een waarde hebben indien `archiefstatus`\
+        \ niet de\n  waarde \"nog_te_archiveren\" heeft.\n- `archiefactiedatum` moet\
+        \ een waarde hebben indien `archiefstatus` niet de\n  waarde \"nog_te_archiveren\"\
+        \ heeft.\n- `archiefstatus` kan alleen een waarde anders dan \"nog_te_archiveren\"\
+        \n  hebben indien van alle gerelateeerde INFORMATIEOBJECTen het attribuut\n\
+        \  `status` de waarde \"gearchiveerd\" heeft.\n\n**Opmerkingen**\n- je krijgt\
+        \ enkel zaken terug van de zaaktypes die in het autorisatie-JWT\n  vervat\
+        \ zitten.\n- zaaktype zal in de toekomst niet-wijzigbaar gemaakt worden.\n\
+        - indien een zaak heropend moet worden, doe dit dan door een nieuwe status\n\
+        \  toe te voegen die NIET de eindstatus is.\n  Zie de `Status` resource."
       parameters:
       - name: Accept-Crs
         in: header
@@ -2646,14 +3566,19 @@ paths:
         $ref: '#/components/requestBodies/Zaak'
     patch:
       operationId: zaak_partial_update
-      description: "Werk een zaak bij.\n\n**Er wordt gevalideerd op**\n- geldigheid\
-        \ URL naar zaaktype\n- laatsteBetaaldatum mag niet in de toekomst liggen\n\
-        - laatsteBetaaldatum nag niet gezet worden als de betalingsindicatie \"nvt\"\
-        \ is\n\n**Opmerkingen**\n- je krijgt enkel zaken terug van de zaaktypes die\
-        \ in het autorisatie-JWT\n  vervat zitten\n- zaaktype zal in de toekomst niet-wijzigbaar\
-        \ gemaakt worden.\n- indien een zaak heropend moet worden, doe dit dan door\
-        \ een nieuwe status\n  toe te voegen die NIET de eindstatus is. Zie de `Status`\
-        \ resource."
+      description: "Werk een zaak bij.\n\n**Er wordt gevalideerd op**\n- `zaaktype`\
+        \ moet een geldige URL zijn.\n- `laatsteBetaaldatum` mag niet in de toekomst\
+        \ liggen.\n- `laatsteBetaaldatum` mag niet gezet worden als de betalingsindicatie\n\
+        \  \"nvt\" is.\n- `archiefnominatie` moet een waarde hebben indien `archiefstatus`\
+        \ niet de\n  waarde \"nog_te_archiveren\" heeft.\n- `archiefactiedatum` moet\
+        \ een waarde hebben indien `archiefstatus` niet de\n  waarde \"nog_te_archiveren\"\
+        \ heeft.\n- `archiefstatus` kan alleen een waarde anders dan \"nog_te_archiveren\"\
+        \n  hebben indien van alle gerelateeerde INFORMATIEOBJECTen het attribuut\n\
+        \  `status` de waarde \"gearchiveerd\" heeft.\n\n**Opmerkingen**\n- je krijgt\
+        \ enkel zaken terug van de zaaktypes die in het autorisatie-JWT\n  vervat\
+        \ zitten.\n- zaaktype zal in de toekomst niet-wijzigbaar gemaakt worden.\n\
+        - indien een zaak heropend moet worden, doe dit dan door een nieuwe status\n\
+        \  toe te voegen die NIET de eindstatus is. Zie de `Status` resource."
       parameters:
       - name: Accept-Crs
         in: header
@@ -2835,6 +3760,169 @@ paths:
         - zds.scopes.zaken.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Zaak'
+    delete:
+      operationId: zaak_delete
+      description: "Verwijdert een zaak, samen met alle gerelateerde resources binnen\
+        \ deze API.\n\n**De gerelateerde resources zijn hierbij**\n- `zaak` - de deelzaken\
+        \ van de verwijderde hoofzaak\n- `status` - alle statussen van de verwijderde\
+        \ zaak\n- `resultaat` - het resultaat van de verwijderde zaak\n- `rol` - alle\
+        \ rollen bij de zaak\n- `zaakobject` - alle zaakobjecten bij de zaak\n- `zaakeigenschap`\
+        \ - alle eigenschappen van de zaak\n- `zaakkenmerk` - alle kenmerken van de\
+        \ zaak\n- `zaakinformatieobject` - dit moet door-cascaden naar DRCs, zie ook\n\
+        \  https://github.com/VNG-Realisatie/gemma-zaken/issues/791 (TODO)\n- `klantcontact`\
+        \ - alle klantcontacten bij een zaak"
+      parameters:
+      - name: Accept-Crs
+        in: header
+        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+          (EPSG:4326 is hetzelfde als WGS84).
+        required: true
+        schema:
+          type: string
+          enum:
+          - EPSG:4326
+      - name: Content-Crs
+        in: header
+        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
+          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+          is hetzelfde als WGS84).
+        required: true
+        schema:
+          type: string
+          enum:
+          - EPSG:4326
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '412':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - zaken
     parameters:
     - name: uuid
       in: path
@@ -3513,6 +4601,12 @@ servers:
 - url: /api/v1
 components:
   requestBodies:
+    Resultaat:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Resultaat'
+      required: true
     Zaak:
       content:
         application/json:
@@ -3659,6 +4753,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'
+    Resultaat:
+      required:
+      - zaak
+      - resultaatType
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        zaak:
+          title: Zaak
+          type: string
+          format: uri
+        resultaatType:
+          title: Resultaat type
+          type: string
+          format: uri
+          maxLength: 200
+          minLength: 1
+        toelichting:
+          title: Toelichting
+          description: Een toelichting op wat het resultaat van de zaak inhoudt.
+          type: string
+          maxLength: 1000
     Rol:
       required:
       - zaak
@@ -3958,6 +5078,7 @@ components:
             van de ZAAK is verlengd (of verkort) ten opzichte van de eerder gecommuniceerde
             doorlooptijd.
           type: string
+          format: duration
     Opschorting:
       title: Opschorting
       description: Gegevens omtrent het tijdelijk opschorten van de behandeling van
@@ -3973,7 +5094,7 @@ components:
           type: boolean
         reden:
           title: Reden
-          description: Omschrijving van de reden voor het opschorten van de 306behandeling
+          description: Omschrijving van de reden voor het opschorten van de behandeling
             van de zaak.
           type: string
           maxLength: 200
@@ -4120,10 +5241,6 @@ components:
           - confidentieel
           - geheim
           - zeer geheim
-        resultaattoelichting:
-          title: Resultaattoelichting
-          description: Een toelichting op wat het resultaat van de zaak inhoudt.
-          type: string
         betalingsindicatie:
           title: Betalingsindicatie
           description: 'Indicatie of de, met behandeling van de zaak gemoeide, kosten
@@ -4205,6 +5322,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ZaakKenmerk'
+        archiefnominatie:
+          title: Archiefnominatie
+          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+          type: string
+          enum:
+          - blijvend_bewaren
+          - vernietigen
+        archiefstatus:
+          title: Archiefstatus
+          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+          type: string
+          enum:
+          - nog_te_archiveren
+          - gearchiveerd
+          - gearchiveerd_procestermijn_onbekend
+          - overgedragen
+        archiefactiedatum:
+          title: Archiefactiedatum
+          description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+            worden dan wel overgebracht moet worden naar een archiefbewaarplaats.
+            Wordt automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT
+            aan deze ZAAK indien nog leeg.
+          type: string
+          format: date
+        resultaat:
+          title: Resultaat
+          description: Indien geen resultaat bekend is, dan is de waarde 'null'
+          type: string
+          format: uri
+          readOnly: true
     GeoWithin:
       title: Zaakgeometrie
       type: object
@@ -4234,6 +5383,52 @@ components:
         zaaktype:
           title: Zaaktype
           description: URL naar het zaaktype in de CATALOGUS waar deze voorkomt
+          type: string
+          minLength: 1
+        archiefnominatie:
+          title: Archiefnominatie
+          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+          type: string
+          minLength: 1
+        archiefnominatie__in:
+          title: Archiefnominatie  in
+          description: Multiple values may be separated by commas.
+          type: string
+          minLength: 1
+        archiefactiedatum:
+          title: Archiefactiedatum
+          description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+            worden dan wel overgebracht moet worden naar een archiefbewaarplaats.
+            Wordt automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT
+            aan deze ZAAK indien nog leeg.
+          type: string
+          minLength: 1
+        archiefactiedatum__lt:
+          title: Archiefactiedatum  lt
+          description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+            worden dan wel overgebracht moet worden naar een archiefbewaarplaats.
+            Wordt automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT
+            aan deze ZAAK indien nog leeg.
+          type: string
+          minLength: 1
+        archiefactiedatum__gt:
+          title: Archiefactiedatum  gt
+          description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+            worden dan wel overgebracht moet worden naar een archiefbewaarplaats.
+            Wordt automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT
+            aan deze ZAAK indien nog leeg.
+          type: string
+          minLength: 1
+        archiefstatus:
+          title: Archiefstatus
+          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+          type: string
+          minLength: 1
+        archiefstatus__in:
+          title: Archiefstatus  in
+          description: Multiple values may be separated by commas.
           type: string
           minLength: 1
     ZaakInformatieObject:
@@ -4271,6 +5466,12 @@ components:
           type: string
           format: uri
           maxLength: 200
+          minLength: 1
+        naam:
+          title: Naam
+          description: De naam van de EIGENSCHAP (overgenomen uit ZTC).
+          type: string
+          readOnly: true
           minLength: 1
         waarde:
           title: Waarde

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -345,9 +345,9 @@ en `Zaak.archiefactiedatum` bepaald worden als volgt:
             * `termijn` -> `Zaak.einddatum` + `Resultaat.Resultaattype.brondatumArchiefprocedure.procestermijn`
             * `gerelateerde_zaak` -> TODO
             * `ingangsdatum_besluit` -> maximale `Besluit.ingangsdatum` van alle
-              gerelateerde besbluiten
+              gerelateerde besluiten
             * `vervaldatum_besluit` -> maximale `Besluit.vervaldatum` van alle
-              gerelateerde besbluiten
+              gerelateerde besluiten
     2. Zet `Zaak.archiefactiedatum` als `brondatum + Resultaat.Resultaattype.archiefactietermijn`
 
 Indien de archiefactiedatum niet bepaald kan worden, dan MAG er geen datum


### PR DESCRIPTION
# API specificatie aanpassing

Voegt support toe voor archivering aan ZRC, DRC en BRC.


* Zie: [User Story #345](https://github.com/VNG-Realisatie/gemma-zaken/issues/345)
* Zie: [User Story #348](https://github.com/VNG-Realisatie/gemma-zaken/issues/348)
* Zie: [User Story #349](https://github.com/VNG-Realisatie/gemma-zaken/issues/349)


## ZRC

**Links**

* [Aanpassingen 1](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/40)
* [Aanpassingen 2](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/41)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-345-archivering-parameters/api-specificatie/zrc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Toevoeging `Resultaat` resource
* Toevoeging `Zaak.archiefnominatie`, `Zaak.archiefactiedatum` en `Zaak.archiefstatus`
* List/search filters voor `Zaak` op `archiefnominatie`, `archiefactiedatum` en `archiefstatus`
* `Eigenschap.naam` attribuut toegevoegd
* `destroy` operaties toegevoegd op `Resultaat` en `Zaak` resource

**Kanttekeningen**

* `Resultaat` is als aparte resource opgezet, met een 1-op-1 relatie naar 
  `Zaak`.
* `Eigenschap.naam` is alleen-lezen en afgeleid uit de beschrijving van de 
  eigenschap in het ZTC
* `destroy` op `Zaak` moet door-cascaden naar gerelateerde objecten

## DRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/pull/37)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-345-archivering-parameters/api-specificatie/drc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* `destroy` operatie toegevoegd op `EnkelvoudigeInformatieobject`
* `destroy` operatie toegevoegd op `ObjectInformatieobject`
* toevoeging scope `scopes.documenten.verwijderen`

## BRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-besluitregistratiecomponent/pull/X)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/us-345-archivering-parameters/api-specificatie/brc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* `destroy` operatie toegevoegd op `Besluit`
* toevoeging scope `scopes.besluiten.verwijderen`

# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
- [ ] Wijzigingen duidelijk omschreven en akkoord (@michielverhoef)
- [ ] Voldoet aan RGBZ of afwijkingen zijn akkoord (@Remkodehaas)
