### PR TITLE
Fixes #609 -- documenteer afleiding InformatieObject.vertrouwelijkheidaanduiding

### DIFF
--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -2831,8 +2831,9 @@ components:
           uniqueItems: true
     InformatieObjectType:
       required:
-      - omschrijving
       - catalogus
+      - omschrijving
+      - vertrouwelijkheidaanduiding
       type: object
       properties:
         url:
@@ -2840,17 +2841,31 @@ components:
           type: string
           format: uri
           readOnly: true
+        catalogus:
+          title: Maakt deel uit van
+          description: De CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.
+          type: string
+          format: uri
         omschrijving:
           title: Omschrijving
           description: Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.
           type: string
           maxLength: 80
           minLength: 1
-        catalogus:
-          title: Maakt deel uit van
-          description: De CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.
+        vertrouwelijkheidaanduiding:
+          title: Vertrouwelijkheidaanduiding
+          description: Aanduiding van de mate waarin informatieobjecten van dit INFORMATIEOBJECTTYPE
+            voor de openbaarheid bestemd zijn.
           type: string
-          format: uri
+          enum:
+          - openbaar
+          - beperkt openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer geheim
     ReferentieProces:
       title: Referentieproces
       description: Het Referentieproces dat ten grondslag ligt aan dit ZAAKTYPE.

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -529,6 +529,18 @@ op `true` zetten.
 Indien de laatste gebruiksrechten op een informatieobject verwijderd worden,
 dan MOET de indicatie weer op `null` gezet worden.
 
+#### Vertrouwelijkheidaanduiding van een informatieobject
+
+Indien de client een `vertrouwelijkheidaanduiding` meegeeft bij het aanmaken
+of bewerken van een informatieobject, dan MOET de provider deze waarde
+toekennen. Indien de client deze niet expliciet toekent, dan MOET deze afgeleid
+worden uit `InformatieOject.InformatieObjectType.vertrouwelijkheidaanduiding`.
+
+Een `InformatieOject` response van de provider MOET altijd een geldige waarde
+voor `vertrouwelijkheidaanduiding` bevatten. Een client MAG een waarde voor
+`vertrouwelijkheidaanduiding` meesturen.
+
+
 ## Besluitregistratiecomponent
 
 Besluitregistratiecomponenten (BRC) MOETEN aan twee aspecten voldoen:


### PR DESCRIPTION
# API specificatie aanpassing

De vertrouwelijkheidaanduiding van een informatieobject moet altijd een waarde
hebben in het DRC. Optioneel wordt deze afgeleid uit het informatieobjecttype.

* Zie: [User Story](https://github.com/VNG-Realisatie/gemma-zaken/issues/609)

## DRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/pull/39)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/609-io-vertrouwelijkaanduiding/api-specificatie/drc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* `InformatieObject.vertrouwelijkheidaanduiding` is gegarandeerd ingevuld

**Kanttekeningen**

* De invulling gebeurt door de consumer (expliciet) of impliciet door de 
  provider op basis van `InformatieObjectType.vertrouwelijkheidaanduiding`

## ZTC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/32)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/609-io-vertrouwelijkaanduiding/api-specificatie/ztc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* `InformatieObjectType.vertrouwelijkheidaanduiding` toegevoegd
* `InformatieObjectType.vertrouwelijkheidaanduiding` bevat altijd een waarde

**Kanttekeningen**

* `InformatieObjectType.vertrouwelijkheidaanduiding` wordt niet uit `Zaaktype`
  afgeleid. Op het moment van informatieobject aanmaken (al dan niet voor een 
  zaak) is niet bekend welk zaaktype relevant is, en een IOT kan voor meerdere
  zaaktypen met verschillende `vertrouwelijkheidaanduiding` relevant zijn,
  wat het 'afleiden' niet-deterministisch maakt en onduidelijk om te kiezen
  welke de 'juiste' is. Daarom verplichten we in het ZTC dat op elke IOT
  de vertrouwelijkheidaanduiding ingesteld wordt. Dit belemmert de werking
  in principe niet - het opvragen van informatieobjecten met een bepaalde VA
  is een autorisatieprobleem, niet een data-probleem.

# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
- [x] Wijzigingen duidelijk omschreven en akkoord
- [ ] Voldoet aan RGBZ of afwijkingen zijn akkoord
