### PR TITLE
Update API-spec NRC with flattened filters

### DIFF
--- a/api-specificatie/nc/openapi.yaml
+++ b/api-specificatie/nc/openapi.yaml
@@ -1348,31 +1348,16 @@ components:
       scheme: bearer
       type: http
   schemas:
-    Filter:
-      required:
-      - key
-      - value
-      type: object
-      properties:
-        key:
-          title: Sleutel
-          type: string
-          maxLength: 100
-          minLength: 1
-        value:
-          title: Waarde
-          type: string
-          maxLength: 1000
-          minLength: 1
     FilterGroup:
       required:
       - naam
       type: object
       properties:
         filters:
-          type: array
-          items:
-            $ref: '#/components/schemas/Filter'
+          title: Filters
+          type: object
+          additionalProperties:
+            type: string
         naam:
           title: Naam
           type: string
@@ -1584,10 +1569,9 @@ components:
           type: string
           format: date-time
         kenmerken:
-          type: array
-          items:
-            type: object
-            additionalProperties:
-              type: string
-              maxLength: 1000
-              minLength: 1
+          title: Kenmerken
+          type: object
+          additionalProperties:
+            type: string
+            maxLength: 1000
+            minLength: 1

--- a/docs/_content/ontwikkelaars/notificeren.md
+++ b/docs/_content/ontwikkelaars/notificeren.md
@@ -89,6 +89,10 @@ JWT te genereren.
    [Notificaties publiceren](#ik-wil-als-bron-notificaties-publiceren). Voor
    het vervolg nemen we aan dat dit beschikbaar is op `https://my-consumer.nl/api/callbacks`
 
+   Indien je geen publiek endpoint kan bouwen, kun je overwegen om de
+   [webhook-site][webhook-site] te gebruiken waar notificaties naartoe gestuurd
+   worden.
+
 2. Vraag op welke kanalen beschikbaar zijn:
 
     ```http
@@ -154,3 +158,4 @@ JWT te genereren.
     ```
 
 [token-generator]: https://ref.tst.vng.cloud/tokens/
+[webhook-site]: https://webhook.site

--- a/docs/_content/ontwikkelaars/notificeren.md
+++ b/docs/_content/ontwikkelaars/notificeren.md
@@ -28,6 +28,7 @@ JWT te genereren.
 
    ```http
    GET https://ref.tst.vng.cloud/nc/api/v1/kanaal?naam=zaken HTTP/1.0
+   Authorization: Bearer abcd1234
    ```
 
    Indien een lege lijst terugkomt, dan bestaat het kanaal nog niet. Indien het
@@ -69,11 +70,11 @@ JWT te genereren.
       "resourceUrl": "https://ref.tst.vng.cloud/zrc/api/v1/statussen/44fdcebf",
       "actie": "create",
       "aanmaakdatum": "2019-03-27T10:59:13Z",
-      "kenmerken": [
-        {"bronorganisatie": "224557609"},
-        {"zaaktype": "https://ref.tst.vng.cloud/ztc/api/v1/catalogussen/39732928/zaaktypen/53c5c164"},
-        {"vertrouwelijkheidaanduiding": "openbaar"}
-      ]
+      "kenmerken": {
+        "bronorganisatie": "224557609",
+        "zaaktype": "https://ref.tst.vng.cloud/ztc/api/v1/catalogussen/39732928/zaaktypen/53c5c164",
+        "vertrouwelijkheidaanduiding": "openbaar"
+      }
     }
     ```
 
@@ -108,9 +109,9 @@ JWT te genereren.
       "kanalen": [
         {
           "naam": "zaken",
-          "filters": [
-            {"bronorganisatie": "224557609"}
-          ]
+          "filters": {
+            "bronorganisatie": "224557609"
+          }
         }
       ]
     }
@@ -144,11 +145,11 @@ JWT te genereren.
       "resourceUrl": "https://ref.tst.vng.cloud/zrc/api/v1/statussen/44fdcebf",
       "actie": "create",
       "aanmaakdatum": "2019-03-27T10:59:13Z",
-      "kenmerken": [
-        {"bronorganisatie": "224557609"},
-        {"zaaktype": "https://ref.tst.vng.cloud/ztc/api/v1/catalogussen/39732928/zaaktypen/53c5c164"},
-        {"vertrouwelijkheidaanduiding": "openbaar"}
-      ]
+      "kenmerken": {
+        "bronorganisatie": "224557609",
+        "zaaktype": "https://ref.tst.vng.cloud/ztc/api/v1/catalogussen/39732928/zaaktypen/53c5c164",
+        "vertrouwelijkheidaanduiding": "openbaar"
+      }
     }
     ```
 


### PR DESCRIPTION
Het formaat hoe filters en kenmerken gecommuniceerd worden is vereenvoudigd van:

```json
{
  "kenmerken": [
    {"kenmerk1": "waarde1"},
    {"kenmerk2": "waarde2"}
  ]
}
```
naar
```json
{
  "kenmerken": {
    "kenmerk1": "waarde1",
    "kenmerk2": "waarde2"
  }
}
```

De volgorde van de kenmerken maakt niet langer uit - de eerste versie was er omdat de JSON-spec intrinsiek geen volgorde toekent. Aangezien de componenten hun kanalen registreren en daarbij in de juiste volgorde van kenmerken communiceren naar het NRC, is de volgorde bij het NRC bekend en kan de berichtstructuur 'losser' in de rest van het systeem.