### PR TITLE
Update NRC API spec & voeg consumer API spec toe

### DIFF
--- a/api-specificatie/nrc/consumer-api/openapi.yaml
+++ b/api-specificatie/nrc/consumer-api/openapi.yaml
@@ -1,0 +1,272 @@
+openapi: 3.0.0
+info:
+  title: Notifications webhook receiver
+  description: API Specification to be able to receive notifications from the NRC
+  contact:
+    url: https://github.com/VNG-Realisatie/gemma-zaken
+  version: '1'
+paths:
+  /{webhooks_path}:
+    post:
+      operationId: notification_receive
+      description: Ontvang notificaties via webhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Notificatie'
+        required: true
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '502':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '503':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - Notificaties
+    parameters:
+    - name: webhooks_path
+      in: path
+      required: true
+      schema:
+        type: string
+servers:
+- url: /
+components:
+  schemas:
+    Notificatie:
+      required:
+      - kanaal
+      - hoofdObject
+      - resource
+      - resourceUrl
+      - actie
+      - aanmaakdatum
+      type: object
+      properties:
+        kanaal:
+          title: kanaal
+          type: string
+          maxLength: 50
+          minLength: 1
+        hoofdObject:
+          title: URL naar het hoofdobject
+          type: string
+          format: uri
+          minLength: 1
+        resource:
+          title: resource
+          type: string
+          maxLength: 100
+          minLength: 1
+        resourceUrl:
+          title: URL naar de resource waarover de notificatie gaat
+          type: string
+          format: uri
+          minLength: 1
+        actie:
+          title: actie
+          type: string
+          maxLength: 100
+          minLength: 1
+        aanmaakdatum:
+          title: aanmaakdatum
+          type: string
+          format: date-time
+        kenmerken:
+          title: Kenmerken
+          type: object
+          additionalProperties:
+            type: string
+            maxLength: 1000
+            minLength: 1
+    FieldValidationError:
+      required:
+      - name
+      - code
+      - reason
+      type: object
+      properties:
+        name:
+          title: Name
+          description: Naam van het veld met ongeldige gegevens
+          type: string
+          minLength: 1
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        reason:
+          title: Reason
+          description: Uitleg wat er precies fout is met de gegevens
+          type: string
+          minLength: 1
+    ValidatieFout:
+      required:
+      - code
+      - title
+      - status
+      - detail
+      - instance
+      - invalid-params
+      type: object
+      properties:
+        type:
+          title: Type
+          description: URI referentie naar het type fout, bedoeld voor developers
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: Extra informatie bij de fout, indien beschikbaar
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1
+        invalid-params:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldValidationError'
+    Fout:
+      required:
+      - code
+      - title
+      - status
+      - detail
+      - instance
+      type: object
+      properties:
+        type:
+          title: Type
+          description: URI referentie naar het type fout, bedoeld voor developers
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: Extra informatie bij de fout, indien beschikbaar
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1

--- a/api-specificatie/nrc/openapi.yaml
+++ b/api-specificatie/nrc/openapi.yaml
@@ -1536,36 +1536,35 @@ components:
       - resourceUrl
       - actie
       - aanmaakdatum
-      - kenmerken
       type: object
       properties:
         kanaal:
-          title: Kanaal
+          title: kanaal
           type: string
           maxLength: 50
           minLength: 1
         hoofdObject:
-          title: Hoofdobject
+          title: URL naar het hoofdobject
           type: string
           format: uri
           minLength: 1
         resource:
-          title: Resource
+          title: resource
           type: string
           maxLength: 100
           minLength: 1
         resourceUrl:
-          title: Resourceurl
+          title: URL naar de resource waarover de notificatie gaat
           type: string
           format: uri
           minLength: 1
         actie:
-          title: Actie
+          title: actie
           type: string
           maxLength: 100
           minLength: 1
         aanmaakdatum:
-          title: Aanmaakdatum
+          title: aanmaakdatum
           type: string
           format: date-time
         kenmerken:

--- a/docs/_content/standaard/apis/nrc.md
+++ b/docs/_content/standaard/apis/nrc.md
@@ -19,7 +19,8 @@ Het ondersteunt:
 
 ![Jenkins][jenkins]
 
-* [API-specificatie](https://ref.tst.vng.cloud/nrc/api/v1/schema/)
+* [API-specificatie (provider)](https://ref.tst.vng.cloud/nrc/api/v1/schema/)
+* [API-specificatie (consumer)](https://rebilly.github.io/ReDoc/?url=https://ref.tst.vng.cloud/api-specificatie/nrc/consumer-api/openapi.yaml)
 * [Referentie implementatie](https://github.com/VNG-Realisatie/gemma-notificatiecomponent)
 * Communiceren met dit component (client)
 * Zelf dit component implementeren (server)

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -148,6 +148,14 @@ Componenten dienen events te publiceren naar (een)
 notificatierouteringcomponent(en) (NRC). De NRC MOET volledig de
 [`openapi.yaml`](../../../api-specificatie/nrc/openapi.yaml) implementeren.
 
+Applicaties MOGEN een abonnement nemen op 1 of meer kanalen. Deze applicaties
+zijn dan event consumers. Een event consumer MOET de
+[API volgens `openapi.yaml`](../../../api-specificatie/nrc/consumer-api/openapi.yaml)
+implementeren om berichten te kunnen ontvangen.
+
+Componenten geven aan indien het nemen van een abonnement op bepaalde kanalen
+verplicht is. Deze componenten zijn dan naast provider ook een event consumer.
+
 ### Kanalen
 
 Elke bron, wat bij de ZGW API's één-op-éen overeen komt met een component


### PR DESCRIPTION
Fixes #806

* Message format/documentation of Notification is now exactly the same
* API-spec allowing for endpoint-variation added, to be implemented by
  webhook subscribers
* Documentation updated to link to API specs