### PR TITLE
Een aantal Engelse beschrijvingen van filterparameters vertaald naar het Nederlands

### DIFF
--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -2039,14 +2039,14 @@ paths:
       parameters:
       - name: zaaktype
         in: query
-        description: URL to the related resource
+        description: URL naar het gerelateerde zaaktype
         required: false
         schema:
           type: string
           format: uri
       - name: pagina
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         required: false
         schema:
           type: integer
@@ -2344,7 +2344,7 @@ paths:
 
         - zaaktype: URL van het zaaktype
 
-        - informatie_object_type: URL van het zaaktype
+        - informatie_object_type: URL van het informatieobjecttype
 
         - richting: waarde van de richting (string)
 
@@ -2353,14 +2353,14 @@ paths:
       parameters:
       - name: zaaktype
         in: query
-        description: URL to the related resource
+        description: URL naar het gerelateerde zaaktype
         required: false
         schema:
           type: string
           format: uri
       - name: informatieObjectType
         in: query
-        description: URL to the related resource
+        description: URL naar het gerelateerde informatieObjectType
         required: false
         schema:
           type: string


### PR DESCRIPTION
Bij het implementeren van de ZTC api viel me op dat een aantal van de beschrijvingen van filterparameters in het Engels naar voren kwamen in Postman. 

Om de documentatie consequent te houden heb ik deze teksten vertaald naar het Nederlands. 