### PR TITLE
Refs. #838 -- autorisaties in ZRC op basis van AC

### DIFF
--- a/api-specificatie/ac/openapi.yml
+++ b/api-specificatie/ac/openapi.yml
@@ -1,3 +1,1193 @@
----
+openapi: 3.0.0
+info:
+  title: Autorisatiecomponent (AC) API
+  description: 'Een API om een autorisatiecomponent te benaderen.
 
-# Coming soon!
+
+    De `AUTORISATIE` is het kernobject in deze API. Autorisaties worden toegekend
+
+    aan applicaties. Een applicatie is een representatie van een (web) app die
+
+    communiceert met de API van (andere) componenten, zoals het ZRC, DRC, ZTC en
+
+    BRC.
+
+
+    Deze API laat toe om autorisaties van een (taak)applicatie te beheren en uit
+
+    te lezen.
+
+
+    **Autorisatie**
+
+
+    Deze API vereist autorisatie. Je kan de
+
+    [token-tool](https://ref.tst.vng.cloud/tokens/) gebruiken om JWT-tokens te
+
+    genereren.
+
+
+    **Notificaties**
+
+
+    Deze component publiceert notificaties op het kanaal `TODO`.
+
+
+    **Handige links**
+
+
+    * [Aan de slag](https://ref.tst.vng.cloud/ontwikkelaars/)
+
+    * ["Papieren" standaard](https://ref.tst.vng.cloud/standaard/)
+
+    '
+  contact:
+    url: https://github.com/VNG-Realisatie/gemma-zaken
+    email: support@maykinmedia.nl
+  license:
+    name: EUPL 1.2
+    url: https://opensource.org/licenses/EUPL-1.2
+  version: 1.0.0-alpha
+security:
+- JWT-Claims: []
+paths:
+  /applicaties:
+    get:
+      operationId: applicatie_list
+      summary: Geef een collectie van applicaties, met ingesloten autorisaties.
+      description: 'De autorisaties zijn gedefinieerd op een specifieke component,
+        bijvoorbeeld
+
+        het ZRC, en geven aan welke scopes van toepassing zijn voor dit component.
+
+        De waarde van de `component` bepaalt ook welke verdere informatie ingesloten
+
+        is, zoals `zaaktype` en `maxVertrouwelijkheidaanduiding` voor het ZRC.
+
+
+        In dit voorbeeld gelden er dus zaaktype-specifieke scopes en mogen zaken
+
+        van het betreffende zaaktype met een striktere vertrouwelijkheidaanduiding
+
+        dan `maxVertrouwelijkheidaanduiding` niet ontsloten worden.
+
+
+        De collectie kan doorzocht worden met de ``clientIds`` query parameter.'
+      parameters:
+      - name: clientIds
+        in: query
+        description: Multiple values may be separated by commas.
+        required: false
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: A page number within the paginated result set.
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                required:
+                - count
+                - results
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Applicatie'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - applicaties
+      security:
+      - JWT-Claims:
+        - autorisaties.lezen
+    post:
+      operationId: applicatie_create
+      summary: Registreer een applicatie met een bepaalde set van autorisaties.
+      description: 'Indien `heeftAlleAutorisaties` gezet is, dan moet je
+
+        `autorisaties` leeg (of weg) laten.
+
+
+        Indien je `autorisaties` meegeeft, dan moet `heeftAlleAutorisaties` de
+
+        waarde `false` hebben of weggelaten worden.
+
+
+        Na het aanmaken wordt een notificatie verstuurd.'
+      responses:
+        '201':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicatie'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - applicaties
+      security:
+      - JWT-Claims:
+        - autorisaties.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/Applicatie'
+    parameters: []
+  /applicaties/{uuid}:
+    get:
+      operationId: applicatie_read
+      summary: Vraag een applicatie op, met ingesloten autorisaties.
+      description: 'De autorisaties zijn gedefinieerd op een specifieke component,
+        bijvoorbeeld
+
+        het ZRC, en geven aan welke scopes van toepassing zijn voor dit component.
+
+        De waarde van de `component` bepaalt ook welke verdere informatie ingesloten
+
+        is, zoals `zaaktype` en `maxVertrouwelijkheidaanduiding` voor het ZRC.
+
+
+        In dit voorbeeld gelden er dus zaaktype-specifieke scopes en mogen zaken
+
+        van het betreffende zaaktype met een striktere vertrouwelijkheidaanduiding
+
+        dan `maxVertrouwelijkheidaanduiding` niet ontsloten worden.'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicatie'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - applicaties
+      security:
+      - JWT-Claims:
+        - autorisaties.lezen
+    put:
+      operationId: applicatie_update
+      summary: Werk de applicatie bij.
+      description: 'Indien `heeftAlleAutorisaties` gezet is, dan moet je
+
+        `autorisaties` leeg (of weg) laten.
+
+
+        Indien je `autorisaties` meegeeft, dan moet `heeftAlleAutorisaties` de
+
+        waarde `false` hebben of weggelaten worden.
+
+
+        Na het bijwerken wordt een notificatie verstuurd.'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicatie'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - applicaties
+      security:
+      - JWT-Claims:
+        - autorisaties.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/Applicatie'
+    patch:
+      operationId: applicatie_partial_update
+      summary: Werk (een deel van) de applicatie bij.
+      description: 'Indien `autorisaties` meegegeven is, dan worden de bestaande `autorisaties`
+
+        vervangen met de nieuwe set van `autorisaties`.
+
+
+        Indien `heeftAlleAutorisaties` gezet is, dan moet je
+
+        `autorisaties` leeg (of weg) laten.
+
+
+        Indien je `autorisaties` meegeeft, dan moet `heeftAlleAutorisaties` de
+
+        waarde `false` hebben of weggelaten worden.
+
+
+        Na het bijwerken wordt een notificatie verstuurd.'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicatie'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - applicaties
+      security:
+      - JWT-Claims:
+        - autorisaties.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/Applicatie'
+    delete:
+      operationId: applicatie_delete
+      summary: Verwijder een applicatie met de bijhorende autorisaties.
+      description: Na het verwijderen wordt een notificatie verstuurd.
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - applicaties
+      security:
+      - JWT-Claims:
+        - autorisaties.bijwerken
+    parameters:
+    - name: uuid
+      in: path
+      description: Unique resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
+servers:
+- url: /api/v1
+components:
+  requestBodies:
+    Applicatie:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Applicatie'
+      required: true
+  securitySchemes:
+    JWT-Claims:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Autorisatie:
+      required:
+      - component
+      - scopes
+      type: object
+      properties:
+        component:
+          title: Component
+          description: 'Component waarop autorisatie van toepassing is.
+
+
+            De mapping van waarden naar weergave is als volgt:
+
+
+            * `AC` - Autorisatiecomponent
+
+            * `NRC` - Notificatierouteringcomponent
+
+            * `ZRC` - Zaakregistratiecomponent
+
+            * `ZTC` - Zaaktypecatalogus
+
+            * `DRC` - Documentregistratiecomponent
+
+            * `BRC` - Besluitregistratiecomponent'
+          type: string
+          enum:
+          - AC
+          - NRC
+          - ZRC
+          - ZTC
+          - DRC
+          - BRC
+        componentWeergave:
+          title: Component weergave
+          type: string
+          readOnly: true
+          minLength: 1
+        scopes:
+          description: Komma-gescheiden lijst van scope labels.
+          type: array
+          items:
+            title: Scopes
+            type: string
+            maxLength: 100
+            minLength: 1
+        zaaktype:
+          title: Zaaktype
+          description: URL naar het zaaktype waarop de autorisatie van toepassing
+            is.
+          type: string
+          format: uri
+          maxLength: 1000
+        maxVertrouwelijkheidaanduiding:
+          title: Max vertrouwelijkheidaanduiding
+          description: Maximaal toegelaten vertrouwelijkheidaanduiding (inclusief).
+          type: string
+          enum:
+          - openbaar
+          - beperkt openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer geheim
+    Applicatie:
+      required:
+      - clientIds
+      - label
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        clientIds:
+          description: Komma-gescheiden lijst van consumer identifiers (hun client_id).
+          type: array
+          items:
+            title: Client ids
+            type: string
+            maxLength: 50
+            minLength: 1
+        label:
+          title: Label
+          description: Een leesbare representatie van de applicatie, voor eindgebruikers.
+          type: string
+          maxLength: 100
+          minLength: 1
+        heeftAlleAutorisaties:
+          title: Heeft alle autorisaties
+          description: Indien alle autorisaties gegeven zijn, dan hoeven deze niet
+            individueel opgegeven te worden. Gebruik dit alleen als je de consumer
+            helemaal vertrouwt.
+          type: boolean
+        autorisaties:
+          type: array
+          items:
+            $ref: '#/components/schemas/Autorisatie'
+    Fout:
+      required:
+      - code
+      - title
+      - status
+      - detail
+      - instance
+      type: object
+      properties:
+        type:
+          title: Type
+          description: URI referentie naar het type fout, bedoeld voor developers
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: Extra informatie bij de fout, indien beschikbaar
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1
+    FieldValidationError:
+      required:
+      - name
+      - code
+      - reason
+      type: object
+      properties:
+        name:
+          title: Name
+          description: Naam van het veld met ongeldige gegevens
+          type: string
+          minLength: 1
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        reason:
+          title: Reason
+          description: Uitleg wat er precies fout is met de gegevens
+          type: string
+          minLength: 1
+    ValidatieFout:
+      required:
+      - code
+      - title
+      - status
+      - detail
+      - instance
+      - invalid-params
+      type: object
+      properties:
+        type:
+          title: Type
+          description: URI referentie naar het type fout, bedoeld voor developers
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: Extra informatie bij de fout, indien beschikbaar
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1
+        invalid-params:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldValidationError'

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -588,7 +588,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     post:
       operationId: resultaat_create
       summary: Voeg een RESULTAAT voor een ZAAK toe.
@@ -727,7 +727,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.bijwerken
+        - zaken.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Resultaat'
     parameters: []
@@ -860,7 +860,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     put:
       operationId: resultaat_update
       summary: Wijzig het RESULTAAT van een ZAAK.
@@ -1006,7 +1006,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.bijwerken
+        - zaken.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Resultaat'
     patch:
@@ -1154,7 +1154,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.bijwerken
+        - zaken.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Resultaat'
     delete:
@@ -1281,7 +1281,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.bijwerken
+        - zaken.bijwerken
     parameters:
     - name: uuid
       in: path
@@ -1461,6 +1461,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - rollen
+      security:
+      - JWT-Claims:
+        - zaken.lezen
     post:
       operationId: rol_create
       description: Koppel een BETROKKENE aan een ZAAK.
@@ -1594,7 +1597,7 @@ paths:
       - rollen
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.aanmaken
+        - zaken.aanmaken
       requestBody:
         content:
           application/json:
@@ -1729,6 +1732,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - rollen
+      security:
+      - JWT-Claims:
+        - zaken.lezen
     parameters:
     - name: uuid
       in: path
@@ -1887,7 +1893,7 @@ paths:
       - statussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     post:
       operationId: status_create
       summary: Voeg een nieuwe STATUS voor een ZAAK toe.
@@ -2027,7 +2033,7 @@ paths:
       - statussen
       security:
       - JWT-Claims:
-        - (zds.scopes.zaken.aanmaken | zds.scopes.statussen.toevoegen | zds.scopes.zaken.heropenen)
+        - (zaken.aanmaken | zaken.statussen.toevoegen | zaken.heropenen)
       requestBody:
         content:
           application/json:
@@ -2164,7 +2170,7 @@ paths:
       - statussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     parameters:
     - name: uuid
       in: path
@@ -2292,7 +2298,7 @@ paths:
       - zaakobjecten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     post:
       operationId: zaakobject_create
       description: Registreer een ZAAKOBJECT relatie.
@@ -2426,7 +2432,7 @@ paths:
       - zaakobjecten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.aanmaken
+        - zaken.aanmaken
       requestBody:
         content:
           application/json:
@@ -2563,7 +2569,7 @@ paths:
       - zaakobjecten
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     parameters:
     - name: uuid
       in: path
@@ -2853,7 +2859,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     post:
       operationId: zaak_create
       summary: Maak een ZAAK aan.
@@ -3031,7 +3037,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.aanmaken
+        - zaken.aanmaken
       requestBody:
         $ref: '#/components/requestBodies/Zaak'
     parameters: []
@@ -3232,7 +3238,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
       requestBody:
         content:
           application/json:
@@ -3410,7 +3416,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.lezen
+        - zaken.lezen
     put:
       operationId: zaak_update
       summary: Werk een zaak bij.
@@ -3605,7 +3611,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - (zds.scopes.zaken.bijwerken | zds.scopes.zaken.geforceerd-bijwerken)
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
       requestBody:
         $ref: '#/components/requestBodies/Zaak'
     patch:
@@ -3802,7 +3808,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - (zds.scopes.zaken.bijwerken | zds.scopes.zaken.geforceerd-bijwerken)
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
       requestBody:
         $ref: '#/components/requestBodies/Zaak'
     delete:
@@ -3950,7 +3956,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zds.scopes.zaken.verwijderen
+        - zaken.verwijderen
     parameters:
     - name: uuid
       in: path
@@ -4076,6 +4082,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zaken.lezen
     post:
       operationId: zaakinformatieobject_create
       description: ''
@@ -4207,6 +4216,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zaken.bijwerken
       requestBody:
         content:
           application/json:
@@ -4349,6 +4361,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zaken.lezen
     delete:
       operationId: zaakinformatieobject_delete
       description: Verwijder een relatie tussen een zaak en een informatieobject
@@ -4471,6 +4486,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zaken.bijwerken
     parameters:
     - name: uuid
       in: path
@@ -4603,6 +4621,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zaken.lezen
     post:
       operationId: zaakeigenschap_create
       description: Registreer een eigenschap van een ZAAK.
@@ -4734,6 +4755,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zaken.bijwerken
       requestBody:
         content:
           application/json:
@@ -4875,6 +4899,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - zaken.lezen
     parameters:
     - name: uuid
       in: path

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -118,7 +118,7 @@ Voorbeeld van een payload:
 Na succesvolle validatie van het JWT is nu zeker dat de consumer is wie die
 beweert te zijn.
 
-Providers MOETEN voor elke aanroep door de client na te gaan of de client
+Providers MOETEN voor elke aanroep door de client controleren of de client
 geautoriseerd is om deze aanroep uit te voeren.
 
 Providers MOETEN een geconfigureerde autorisatiecomponent bevragen met het
@@ -142,10 +142,14 @@ toe te voegen.
 
 #### Run-time gedrag
 
+De AC MAG bij de registratie van autorisaties die een of meer zaaktypen
+bevatten controleren of de zaaktypen bestaan. Merk op dat hiervoor het AC
+zelf geautoriseerd moet zijn om het ZTC te bevragen.
+
 ##### Uniciteit van `client_ids`
 
 Een applicatie MAG zich met meerdere `client_id`s identificeren, waarbij er
-een `client_id` per provider gebruikt wordt. Eenmaal een `client_id` aan een
+een `client_id` per provider gebruikt wordt. Als eenmaal een `client_id` aan een
 applicatie toegekend is, dan MAG dit `client_id` NIET opnieuw gebruikt worden.
 Een `client_id` identifieert uniek 1 en slechts 1 applicatie.
 

--- a/docs/_content/standaard/standaard.md
+++ b/docs/_content/standaard/standaard.md
@@ -21,6 +21,7 @@ tussen registraties en consumers die van de API's gebruik maken.
 - [Beschikbaar stellen van API-spec](#beschikbaar-stellen-van-api-spec)
 - [Gegevensformaten](#gegevensformaten)
 - [Autorisatie](#autorisatie)
+    - [Autorisatiecomponent](#autorisatiecomponent)
 - [Filter parameters](#filter-parameters)
 - [Notificaties](#notificaties)
 - [Zaakregistratiecomponent](#zaakregistratiecomponent)
@@ -128,6 +129,34 @@ Providers MOGEN deze gegevens cachen om performance-redenen. Indien
 er van caching gebruik gemaakt wordt, dan MOETEN providers een mechanisme
 inbouwen om wijzingen in het AC meteen door te voeren in de cache. Het is
 AANGERADEN om hiervoor te abonneren op notificaties verstuurd door het AC.
+
+### Autorisatiecomponent
+
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/ac/openapi.yaml)
+MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de
+referentie-implementatie van het AC.
+
+Het is NIET TOEGESTAAN om gebruik te maken van operaties die niet beschreven
+staan in deze OAS spec, of om uitbreidingen op operaties in welke vorm dan ook
+toe te voegen.
+
+#### Run-time gedrag
+
+##### Uniciteit van `client_ids`
+
+Een applicatie MAG zich met meerdere `client_id`s identificeren, waarbij er
+een `client_id` per provider gebruikt wordt. Eenmaal een `client_id` aan een
+applicatie toegekend is, dan MAG dit `client_id` NIET opnieuw gebruikt worden.
+Een `client_id` identifieert uniek 1 en slechts 1 applicatie.
+
+##### Autorisatiesspecificatie
+
+Autorisaties MOETEN gespecifieerd worden op 1 van de volgende manieren:
+
+* opvoeren van `Autorisatie`-objecten bij een `Applicatie`, waarbij de vlag
+  `heeftAlleAutorisaties` `false` is
+* het zetten van de vlag `heeftAlleAutorisaties` op `true`, waarbij er GEEN
+  `Autorisatie`-objecten mogen opgevoerd worden
 
 ## Filter parameters
 


### PR DESCRIPTION
# API specificatie aanpassing

Dit is de implementatie van de nieuwe, meer fine-grained opzet voor autorisaties.

In deze opzet heeft de gemeente controle over wie wat mag bij welke zaaktypen. Het steunt op het bestaan van een autorisatiecomponent, die geconsulteerd wordt door de providers.

* Zie: [User Story](https://github.com/VNG-Realisatie/gemma-zaken/issues/838)
* Zie: [Architectuur](https://ref.tst.vng.cloud/ontwikkelaars/algemeen/authenticatie-autorisatie)

## ZRC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-zaakregistratiecomponent/pull/54)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/autorisatie-bis/api-specificatie/zrc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* toevoeging van autorisatie/scopes op de `ZaakInformatieObject`, `Rol`, `ZaakEigenschap` resources
* scope-labels bijgewerkt [breaking change]

**Kanttekeningen**

* het `zds` stuk in de scope labels was niet meer in lijn met de `zgw` namespace, en de APIs voor documenten kunnen breder gebruikt worden. De scopes dekken dan niet meer de lading dat ze 'enkel' voor ZGW van toepassing zouden zijn. Scope labels worden uniform gehouden, dus ook voor ZRC is de namespace erafgehaald.

## AC

**Links**

* [Aanpassingen](https://github.com/VNG-Realisatie/gemma-autorisatiecomponent/pull/4)
* [API documentatie](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/autorisatie-bis/api-specificatie/zrc/openapi.yaml)


**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Toevoeging van autorisatiecomponent
* Toevoeging van de resource `Applicatie`
    * `Applicatie.clientIds` bevat een lijst van client IDs waaronder deze
      applicatie bekend is
    * `Applicatie.autorisaties` bevat een lijst van `Autorisatie` objecten,
      die van toepassing zijn op een bepaalde component en de scopes aangeven,
      eventueel aangevuld met component-specifieke attributen
* AC endpoint-bescherming met scopes: `autorisaties.lezen` en 
  `autorisaties.bijwerken`, zodat clients op AC gebouwd kunnen worden

**Kanttekeningen**

* Deze component wordt als core-component onderkend.