### PR TITLE
Update all API specs after updating to new auth format

### DIFF
--- a/api-specificatie/ac/openapi.yaml
+++ b/api-specificatie/ac/openapi.yaml
@@ -983,9 +983,9 @@ components:
       required: true
   securitySchemes:
     JWT-Claims:
-      bearerFormat: JWT
-      scheme: bearer
       type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     AutorisatieBase:
       required:
@@ -1026,7 +1026,8 @@ components:
           readOnly: true
           minLength: 1
         scopes:
-          description: Komma-gescheiden lijst van scope labels.
+          description: Lijst van scope labels. Elke scope geeft toegang tot een set
+            van acties/operaties, zoals gedocumenteerd bij de betreffende component.
           type: array
           items:
             title: Scopes
@@ -1118,7 +1119,7 @@ components:
           format: uri
           readOnly: true
         clientIds:
-          description: Komma-gescheiden lijst van consumer identifiers (hun client_id).
+          description: Lijst van consumer identifiers (hun 'client_id')
           type: array
           items:
             title: Client ids

--- a/api-specificatie/ac/openapi.yaml
+++ b/api-specificatie/ac/openapi.yaml
@@ -983,11 +983,11 @@ components:
       required: true
   securitySchemes:
     JWT-Claims:
-      type: http
-      scheme: bearer
       bearerFormat: JWT
+      scheme: bearer
+      type: http
   schemas:
-    Autorisatie:
+    AutorisatieBase:
       required:
       - component
       - scopes
@@ -1033,6 +1033,11 @@ components:
             type: string
             maxLength: 100
             minLength: 1
+      discriminator:
+        propertyName: component
+    ZRCAutorisatie:
+      type: object
+      properties:
         zaaktype:
           title: Zaaktype
           description: URL naar het zaaktype waarop de autorisatie van toepassing
@@ -1053,6 +1058,54 @@ components:
           - confidentieel
           - geheim
           - zeer geheim
+    ZRC:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/AutorisatieBase'
+      - $ref: '#/components/schemas/ZRCAutorisatie'
+    DRCAutorisatie:
+      type: object
+      properties:
+        informatieobjecttype:
+          title: Informatieobjecttype
+          description: URL naar het informatieobjecttype waarop de autorisatie van
+            toepassing is.
+          type: string
+          format: uri
+          maxLength: 1000
+        maxVertrouwelijkheidaanduiding:
+          title: Max vertrouwelijkheidaanduiding
+          description: Maximaal toegelaten vertrouwelijkheidaanduiding (inclusief).
+          type: string
+          enum:
+          - openbaar
+          - beperkt openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer geheim
+    DRC:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/AutorisatieBase'
+      - $ref: '#/components/schemas/DRCAutorisatie'
+    BRCAutorisatie:
+      type: object
+      properties:
+        besluittype:
+          title: Besluittype
+          description: URL naar het besluittype waarop de autorisatie van toepassing
+            is.
+          type: string
+          format: uri
+          maxLength: 1000
+    BRC:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/AutorisatieBase'
+      - $ref: '#/components/schemas/BRCAutorisatie'
     Applicatie:
       required:
       - clientIds
@@ -1087,7 +1140,7 @@ components:
         autorisaties:
           type: array
           items:
-            $ref: '#/components/schemas/Autorisatie'
+            $ref: '#/components/schemas/AutorisatieBase'
     Fout:
       required:
       - code
@@ -1155,7 +1208,7 @@ components:
       - status
       - detail
       - instance
-      - invalid-params
+      - invalidParams
       type: object
       properties:
         type:
@@ -1187,7 +1240,7 @@ components:
             Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
-        invalid-params:
+        invalidParams:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'

--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -171,6 +171,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.lezen
     post:
       operationId: besluit_create
       description: 'Registreer een besluit.
@@ -320,6 +323,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.aanmaken
       requestBody:
         $ref: '#/components/requestBodies/Besluit'
     parameters: []
@@ -440,6 +446,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.lezen
     post:
       operationId: besluitinformatieobject_create
       description: "Registreer in welk(e) INFORMATIEOBJECT(en) een BESLUIT vastgelegd\
@@ -574,6 +583,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.aanmaken
       requestBody:
         $ref: '#/components/requestBodies/BesluitInformatieObject'
     parameters:
@@ -711,6 +723,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.lezen
     put:
       operationId: besluitinformatieobject_update
       description: "Werk de relatie tussen een BESLUIT en INFORMATIEOBJECT bij.\n\n\
@@ -852,6 +867,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/BesluitInformatieObject'
     patch:
@@ -995,6 +1013,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/BesluitInformatieObject'
     delete:
@@ -1119,6 +1140,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.verwijderen
     parameters:
     - name: besluit_uuid
       in: path
@@ -1260,6 +1284,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.lezen
     put:
       operationId: besluit_update
       description: 'Werk een BESLUIT bij.
@@ -1411,6 +1438,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Besluit'
     patch:
@@ -1564,6 +1594,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Besluit'
     delete:
@@ -1690,6 +1723,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - besluiten.verwijderen
     parameters:
     - name: uuid
       in: path
@@ -1892,7 +1928,7 @@ components:
       - status
       - detail
       - instance
-      - invalid-params
+      - invalidParams
       type: object
       properties:
         type:
@@ -1924,7 +1960,7 @@ components:
             Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
-        invalid-params:
+        invalidParams:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'

--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -200,6 +200,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.lezen
     post:
       operationId: enkelvoudiginformatieobject_create
       description: 'Registreer een ENKELVOUDIG INFORMATIEOBJECT.
@@ -336,6 +339,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.aanmaken
       requestBody:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectData'
     parameters: []
@@ -471,6 +477,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.lezen
     put:
       operationId: enkelvoudiginformatieobject_update
       description: 'Werk een ENKELVOUDIG INFORMATIEOBJECT bij door de volledige resource
@@ -622,6 +631,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectData'
     patch:
@@ -775,6 +787,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectData'
     delete:
@@ -910,7 +925,7 @@ paths:
       - enkelvoudiginformatieobjecten
       security:
       - JWT-Claims:
-        - scopes.documenten.verwijderen
+        - documenten.verwijderen
     parameters:
     - name: uuid
       in: path
@@ -1119,6 +1134,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - gebruiksrechten
+      security:
+      - JWT-Claims:
+        - documenten.lezen
     post:
       operationId: gebruiksrechten_create
       description: "Voeg gebruiksrechten toe voor een informatieobject.\n\n**Opmerkingen**\n\
@@ -1252,6 +1270,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - gebruiksrechten
+      security:
+      - JWT-Claims:
+        - documenten.aanmaken
       requestBody:
         $ref: '#/components/requestBodies/Gebruiksrechten'
     parameters: []
@@ -1382,6 +1403,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - gebruiksrechten
+      security:
+      - JWT-Claims:
+        - documenten.lezen
     put:
       operationId: gebruiksrechten_update
       description: Werk een gebruiksrecht van een informatieobject bij.
@@ -1520,6 +1544,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - gebruiksrechten
+      security:
+      - JWT-Claims:
+        - documenten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Gebruiksrechten'
     patch:
@@ -1660,6 +1687,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - gebruiksrechten
+      security:
+      - JWT-Claims:
+        - documenten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/Gebruiksrechten'
     delete:
@@ -1787,6 +1817,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - gebruiksrechten
+      security:
+      - JWT-Claims:
+        - documenten.verwijderen
     parameters:
     - name: uuid
       in: path
@@ -1943,6 +1976,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - objectinformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.lezen
     post:
       operationId: objectinformatieobject_create
       description: "Registreer een INFORMATIEOBJECT bij een OBJECT. Er worden twee\
@@ -2084,6 +2120,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - objectinformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.aanmaken
       requestBody:
         $ref: '#/components/requestBodies/ObjectInformatieObject'
     parameters: []
@@ -2217,6 +2256,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - objectinformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.lezen
     put:
       operationId: objectinformatieobject_update
       description: 'Update een INFORMATIEOBJECT bij een OBJECT. Je mag enkel de gegevens
@@ -2367,6 +2409,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - objectinformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/ObjectInformatieObject'
     patch:
@@ -2519,6 +2564,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - objectinformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.bijwerken
       requestBody:
         $ref: '#/components/requestBodies/ObjectInformatieObject'
     delete:
@@ -2643,6 +2691,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - objectinformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.verwijderen
     parameters:
     - name: uuid
       in: path
@@ -3449,7 +3500,7 @@ components:
       - status
       - detail
       - instance
-      - invalid-params
+      - invalidParams
       type: object
       properties:
         type:
@@ -3481,7 +3532,7 @@ components:
             Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
-        invalid-params:
+        invalidParams:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'

--- a/api-specificatie/nrc/openapi.yaml
+++ b/api-specificatie/nrc/openapi.yaml
@@ -197,7 +197,7 @@ paths:
       - abonnement
       security:
       - JWT-Claims:
-        - (notificaties.scopes.consumeren | notificaties.scopes.publiceren)
+        - (notificaties.consumeren | notificaties.publiceren)
     post:
       operationId: abonnement_create
       description: ''
@@ -331,7 +331,7 @@ paths:
       - abonnement
       security:
       - JWT-Claims:
-        - notificaties.scopes.consumeren
+        - notificaties.consumeren
       requestBody:
         $ref: '#/components/requestBodies/Abonnement'
     parameters: []
@@ -464,7 +464,7 @@ paths:
       - abonnement
       security:
       - JWT-Claims:
-        - (notificaties.scopes.consumeren | notificaties.scopes.publiceren)
+        - (notificaties.consumeren | notificaties.publiceren)
     put:
       operationId: abonnement_update
       description: ''
@@ -605,7 +605,7 @@ paths:
       - abonnement
       security:
       - JWT-Claims:
-        - notificaties.scopes.consumeren
+        - notificaties.consumeren
       requestBody:
         $ref: '#/components/requestBodies/Abonnement'
     patch:
@@ -748,7 +748,7 @@ paths:
       - abonnement
       security:
       - JWT-Claims:
-        - notificaties.scopes.consumeren
+        - notificaties.consumeren
       requestBody:
         $ref: '#/components/requestBodies/Abonnement'
     delete:
@@ -875,7 +875,7 @@ paths:
       - abonnement
       security:
       - JWT-Claims:
-        - notificaties.scopes.consumeren
+        - notificaties.consumeren
     parameters:
     - name: uuid
       in: path
@@ -1023,7 +1023,7 @@ paths:
       - kanaal
       security:
       - JWT-Claims:
-        - (notificaties.scopes.publiceren | notificaties.scopes.consumeren)
+        - (notificaties.publiceren | notificaties.consumeren)
     post:
       operationId: kanaal_create
       description: ''
@@ -1157,7 +1157,7 @@ paths:
       - kanaal
       security:
       - JWT-Claims:
-        - notificaties.scopes.publiceren
+        - notificaties.publiceren
       requestBody:
         content:
           application/json:
@@ -1294,7 +1294,7 @@ paths:
       - kanaal
       security:
       - JWT-Claims:
-        - (notificaties.scopes.publiceren | notificaties.scopes.consumeren)
+        - (notificaties.publiceren | notificaties.consumeren)
     parameters:
     - name: uuid
       in: path
@@ -1324,7 +1324,7 @@ paths:
       - notificaties
       security:
       - JWT-Claims:
-        - notificaties.scopes.publiceren
+        - notificaties.publiceren
       requestBody:
         content:
           application/json:
@@ -1461,7 +1461,7 @@ components:
       - status
       - detail
       - instance
-      - invalid-params
+      - invalidParams
       type: object
       properties:
         type:
@@ -1493,7 +1493,7 @@ components:
             Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
-        invalid-params:
+        invalidParams:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -5037,7 +5037,7 @@ components:
       - status
       - detail
       - instance
-      - invalid-params
+      - invalidParams
       type: object
       properties:
         type:
@@ -5069,7 +5069,7 @@ components:
             Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
-        invalid-params:
+        invalidParams:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -175,7 +175,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters: []
   /catalogussen/{catalogus_uuid}/besluittypen:
     get:
@@ -299,7 +299,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -437,7 +437,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -572,7 +572,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -711,7 +711,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -846,7 +846,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -985,7 +985,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1120,7 +1120,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1268,7 +1268,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1438,7 +1438,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1584,7 +1584,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1725,7 +1725,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -1870,7 +1870,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: catalogus_uuid
       in: path
@@ -2023,7 +2023,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: uuid
       in: path
@@ -2191,7 +2191,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters: []
   /resultaattypen/{uuid}:
     get:
@@ -2325,7 +2325,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: uuid
       in: path
@@ -2503,7 +2503,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters: []
   /zaaktype-informatieobjecttypen/{uuid}:
     get:
@@ -2634,7 +2634,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zds.scopes.zaaktypes.lezen
+        - zaaktypes.lezen
     parameters:
     - name: uuid
       in: path
@@ -3338,7 +3338,7 @@ components:
       - status
       - detail
       - instance
-      - invalid-params
+      - invalidParams
       type: object
       properties:
         type:
@@ -3370,7 +3370,7 @@ components:
             Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
-        invalid-params:
+        invalidParams:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'


### PR DESCRIPTION
Dit zijn de laatste wijzigingen op de API specs voor alle componenten

* Alle referentie-implementaties zijn overgezet naar nieuwe autorisatie format
* Alle operaties die nog niet middels een scope afgedekt waren, zijn dat nu wel
* Er zijn kleine fixes doorgevoerd i.v.m. landelijke API-strategie (zoals `invalid-params` -> `invalidParams`)

**Related user stories**

* Fixes #839
* Fixes #699