### PR TITLE
API specificatie updates

### DIFF
--- a/api-specificatie/ac/openapi.yaml
+++ b/api-specificatie/ac/openapi.yaml
@@ -83,7 +83,7 @@ paths:
           type: string
       - name: page
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         required: false
         schema:
           type: integer

--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -596,834 +596,6 @@ paths:
       schema:
         type: string
         format: uuid
-  /besluiten/{besluit_uuid}/informatieobjecten:
-    get:
-      operationId: besluitinformatieobject_list
-      description: Geef een lijst van relaties tussen BESLUITen en INFORMATIEOBJECTen.
-      responses:
-        '200':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/BesluitInformatieObject'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - besluiten
-      security:
-      - JWT-Claims:
-        - besluiten.lezen
-    post:
-      operationId: besluitinformatieobject_create
-      description: "Registreer in welk(e) INFORMATIEOBJECT(en) een BESLUIT vastgelegd\
-        \ is.\n\nEr wordt gevalideerd op:\n- geldigheid informatieobject URL\n- uniek\
-        \ zijn van relatie BESLUIT-INFORMATIEOBJECT\n- bestaan van relatie BESLUIT-INFORMATIEOBJECT\
-        \ in het DRC waar het\n  informatieobject leeft"
-      responses:
-        '201':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-            Location:
-              schema:
-                type: string
-                format: uri
-              description: URL waar de resource leeft.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BesluitInformatieObject'
-        '400':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ValidatieFout'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - besluiten
-      security:
-      - JWT-Claims:
-        - besluiten.aanmaken
-      requestBody:
-        $ref: '#/components/requestBodies/BesluitInformatieObject'
-    parameters:
-    - name: besluit_uuid
-      in: path
-      required: true
-      description: Unieke resource identifier (UUID4)
-      schema:
-        type: string
-        format: uuid
-  /besluiten/{besluit_uuid}/informatieobjecten/{uuid}:
-    get:
-      operationId: besluitinformatieobject_read
-      description: Opvragen en bwerken van Besluit-Informatieobject relaties.
-      responses:
-        '200':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BesluitInformatieObject'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '404':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - besluiten
-      security:
-      - JWT-Claims:
-        - besluiten.lezen
-    put:
-      operationId: besluitinformatieobject_update
-      description: "Werk de relatie tussen een BESLUIT en INFORMATIEOBJECT bij.\n\n\
-        Er wordt gevalideerd op:\n- geldigheid informatieobject URL\n- uniek zijn\
-        \ van relatie BESLUIT-INFORMATIEOBJECT\n- bestaan van relatie BESLUIT-INFORMATIEOBJECT\
-        \ in het DRC waar het\n  informatieobject leeft"
-      responses:
-        '200':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BesluitInformatieObject'
-        '400':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ValidatieFout'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '404':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - besluiten
-      security:
-      - JWT-Claims:
-        - besluiten.bijwerken
-      requestBody:
-        $ref: '#/components/requestBodies/BesluitInformatieObject'
-    patch:
-      operationId: besluitinformatieobject_partial_update
-      description: "Werk de relatie tussen een BESLUIT en INFORMATIEOBJECT bij.\n\n\
-        Er wordt gevalideerd op:\n- geldigheid informatieobject URL\n- uniek zijn\
-        \ van relatie BESLUIT-INFORMATIEOBJECT\n- bestaan van relatie BESLUIT-INFORMATIEOBJECT\
-        \ in het DRC waar het\n  informatieobject leeft"
-      responses:
-        '200':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BesluitInformatieObject'
-        '400':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ValidatieFout'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '404':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - besluiten
-      security:
-      - JWT-Claims:
-        - besluiten.bijwerken
-      requestBody:
-        $ref: '#/components/requestBodies/BesluitInformatieObject'
-    delete:
-      operationId: besluitinformatieobject_delete
-      description: Ontkoppel een BESLUIT en INFORMATIEOBJECT-relatie.
-      responses:
-        '204':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '404':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - besluiten
-      security:
-      - JWT-Claims:
-        - besluiten.verwijderen
-    parameters:
-    - name: besluit_uuid
-      in: path
-      required: true
-      description: Unieke resource identifier (UUID4)
-      schema:
-        type: string
-        format: uuid
-    - name: uuid
-      in: path
-      required: true
-      schema:
-        type: string
-        format: uuid
   /besluiten/{uuid}:
     get:
       operationId: besluit_read
@@ -2000,6 +1172,867 @@ paths:
       schema:
         type: string
         format: uuid
+  /besluitinformatieobjecten:
+    get:
+      operationId: besluitinformatieobject_list
+      description: 'Geef een lijst van relaties tussen INFORMATIEOBJECTen en BESLUITen.
+
+
+        Deze lijst kan gefilterd wordt met querystringparameters.'
+      parameters:
+      - name: besluit
+        in: query
+        description: URL to the related resource
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: informatieobject
+        in: query
+        description: URL-referentie naar het informatieobject waarin (een deel van)
+          het besluit beschreven is.
+        required: false
+        schema:
+          type: string
+          format: uri
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BesluitInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - besluitinformatieobjecten
+      security:
+      - JWT-Claims:
+        - besluiten.lezen
+    post:
+      operationId: besluitinformatieobject_create
+      description: "Registreer een INFORMATIEOBJECT bij een BESLUIT. Er worden twee\
+        \ types van\nrelaties met andere objecten gerealiseerd:\n\n**Er wordt gevalideerd\
+        \ op**\n- geldigheid besluit URL\n- geldigheid informatieobject URL\n- de\
+        \ combinatie informatieobject en besluit moet uniek zijn\n\n**Opmerkingen**\n\
+        - De registratiedatum wordt door het systeem op 'NU' gezet. De `aardRelatie`\n\
+        \  wordt ook door het systeem gezet.\n- Bij het aanmaken wordt ook in het\
+        \ DRC de gespiegelde relatie aangemaakt,\n  echter zonder de relatie-informatie.\n\
+        \n\nRegistreer welk(e) INFORMATIEOBJECT(en) een BESLUIT kent.\n\n**Er wordt\
+        \ gevalideerd op**\n- geldigheid informatieobject URL\n- uniek zijn van relatie\
+        \ BESLUIT-INFORMATIEOBJECT"
+      responses:
+        '201':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BesluitInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - besluitinformatieobjecten
+      security:
+      - JWT-Claims:
+        - besluiten.aanmaken
+      requestBody:
+        $ref: '#/components/requestBodies/BesluitInformatieObject'
+    parameters: []
+  /besluitinformatieobjecten/{uuid}:
+    get:
+      operationId: besluitinformatieobject_read
+      description: Geef de details van een relatie tussen een INFORMATIEOBJECT en
+        een BESLUIT.
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BesluitInformatieObject'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - besluitinformatieobjecten
+      security:
+      - JWT-Claims:
+        - besluiten.lezen
+    put:
+      operationId: besluitinformatieobject_update
+      description: 'Update een INFORMATIEOBJECT bij een BESLUIT. Je mag enkel de gegevens
+
+        van de relatie bewerken, en niet de relatie zelf aanpassen.
+
+
+        **Er wordt gevalideerd op**
+
+        - informatieobject URL en besluit URL mogen niet veranderen'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BesluitInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - besluitinformatieobjecten
+      security:
+      - JWT-Claims:
+        - besluiten.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/BesluitInformatieObject'
+    patch:
+      operationId: besluitinformatieobject_partial_update
+      description: 'Update een INFORMATIEOBJECT bij een BESLUIT. Je mag enkel de gegevens
+
+        van de relatie bewerken, en niet de relatie zelf aanpassen.
+
+
+        **Er wordt gevalideerd op**
+
+        - informatieobject URL en besluit URL mogen niet veranderen'
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BesluitInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - besluitinformatieobjecten
+      security:
+      - JWT-Claims:
+        - besluiten.bijwerken
+      requestBody:
+        $ref: '#/components/requestBodies/BesluitInformatieObject'
+    delete:
+      operationId: besluitinformatieobject_delete
+      description: Verwijdert de relatie tussen BESLUIT en INFORMATIEOBJECT.
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - besluitinformatieobjecten
+      security:
+      - JWT-Claims:
+        - besluiten.verwijderen
+    parameters:
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
 servers:
 - url: /api/v1
 components:
@@ -2380,6 +2413,7 @@ components:
     BesluitInformatieObject:
       required:
       - informatieobject
+      - besluit
       type: object
       properties:
         url:
@@ -2393,5 +2427,17 @@ components:
             het besluit beschreven is.
           type: string
           format: uri
-          maxLength: 200
+          maxLength: 1000
           minLength: 1
+        besluit:
+          title: Besluit
+          description: URL-referentie naar het BESLUIT.
+          type: string
+          format: uri
+        aardRelatieWeergave:
+          title: Aard relatie weergave
+          type: string
+          enum:
+          - 'Hoort bij, omgekeerd: kent'
+          - 'Legt vast, omgekeerd: kan vastgelegd zijn als'
+          readOnly: true

--- a/api-specificatie/drc/openapi.yaml
+++ b/api-specificatie/drc/openapi.yaml
@@ -53,10 +53,9 @@ paths:
   /enkelvoudiginformatieobjecten:
     get:
       operationId: enkelvoudiginformatieobject_list
-      description: 'Geef een lijst van ENKELVOUDIGe INFORMATIEOBJECTen (=documenten).
-
-
-        De objecten bevatten metadata over de documenten en de downloadlink naar
+      summary: Geef een lijst van ENKELVOUDIGe INFORMATIEOBJECTen (=documenten).
+      description: 'De objecten bevatten metadata over de documenten en de downloadlink
+        naar
 
         de binary data.'
       parameters:
@@ -205,12 +204,31 @@ paths:
         - documenten.lezen
     post:
       operationId: enkelvoudiginformatieobject_create
-      description: 'Registreer een ENKELVOUDIG INFORMATIEOBJECT.
-
-
-        **Er wordt gevalideerd op**
+      summary: Registreer een ENKELVOUDIG INFORMATIEOBJECT.
+      description: '**Er wordt gevalideerd op**
 
         - geldigheid informatieobjecttype URL'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -462,6 +480,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - audittrails.lezen
     parameters:
     - name: enkelvoudiginformatieobject_uuid
       in: path
@@ -597,6 +618,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - audittrails.lezen
     parameters:
     - name: enkelvoudiginformatieobject_uuid
       in: path
@@ -615,10 +639,9 @@ paths:
   /enkelvoudiginformatieobjecten/{uuid}:
     get:
       operationId: enkelvoudiginformatieobject_read
-      description: 'Geef de details van een ENKELVOUDIG INFORMATIEOBJECT.
-
-
-        Het object bevat metadata over het informatieobject en de downloadlink naar
+      summary: Geef de details van een ENKELVOUDIG INFORMATIEOBJECT.
+      description: 'Het object bevat metadata over het informatieobject en de downloadlink
+        naar
 
         de binary data.'
       responses:
@@ -749,13 +772,11 @@ paths:
         - documenten.lezen
     put:
       operationId: enkelvoudiginformatieobject_update
-      description: 'Werk een ENKELVOUDIG INFORMATIEOBJECT bij door de volledige resource
+      summary: 'Werk een ENKELVOUDIG INFORMATIEOBJECT bij door de volledige resource
         mee
 
-        te sturen.
-
-
-        **Er wordt gevalideerd op**
+        te sturen.'
+      description: '**Er wordt gevalideerd op**
 
         - geldigheid informatieobjecttype URL
 
@@ -763,6 +784,27 @@ paths:
         *TODO*
 
         - valideer immutable attributes'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -905,13 +947,11 @@ paths:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectData'
     patch:
       operationId: enkelvoudiginformatieobject_partial_update
-      description: 'Werk een ENKELVOUDIG INFORMATIEOBJECT bij door enkel de gewijzigde
+      summary: 'Werk een ENKELVOUDIG INFORMATIEOBJECT bij door enkel de gewijzigde
         velden
 
-        mee te sturen.
-
-
-        **Er wordt gevalideerd op**
+        mee te sturen.'
+      description: '**Er wordt gevalideerd op**
 
         - geldigheid informatieobjecttype URL
 
@@ -919,6 +959,27 @@ paths:
         *TODO*
 
         - valideer immutable attributes'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1061,16 +1122,35 @@ paths:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectData'
     delete:
       operationId: enkelvoudiginformatieobject_delete
-      description: 'Verwijdert een ENKELVOUDIG INFORMATIEOBJECT, samen met alle gerelateerde
+      summary: 'Verwijdert een ENKELVOUDIG INFORMATIEOBJECT, samen met alle gerelateerde
 
-        resources binnen deze API.
-
-
-        **Gerelateerde resources**
+        resources binnen deze API.'
+      description: '**Gerelateerde resources**
 
         - `ObjectInformatieObject` - alle relaties van het informatieobject
 
         - `Gebruiksrechten` - alle gebruiksrechten van het informatieobject'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -1201,17 +1281,426 @@ paths:
       schema:
         type: string
         format: uuid
+  /enkelvoudiginformatieobjecten/{uuid}/download:
+    get:
+      operationId: enkelvoudiginformatieobject_download
+      description: Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.
+      responses:
+        '200':
+          description: De binaire bestandsinhoud
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Unauthorized
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: Forbidden
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: Not found
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: Not acceptable
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: Gone
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: Unsupported media type
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: Throttled
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: Internal server error
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.lezen
+    parameters:
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
+  /enkelvoudiginformatieobjecten/{uuid}/lock:
+    post:
+      operationId: enkelvoudiginformatieobject_lock
+      description: Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LockEnkelvoudigInformatieObject'
+        '400':
+          description: Bad request
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '401':
+          description: Unauthorized
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: Forbidden
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: Not found
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: Not acceptable
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: Gone
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: Unsupported media type
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: Throttled
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: Internal server error
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - documenten.lock
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LockEnkelvoudigInformatieObject'
+        required: true
+    parameters:
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
+  /enkelvoudiginformatieobjecten/{uuid}/unlock:
+    post:
+      operationId: enkelvoudiginformatieobject_unlock
+      description: Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.
+      responses:
+        '204':
+          description: No content
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '400':
+          description: Bad request
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '401':
+          description: Unauthorized
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: Forbidden
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: Not found
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: Not acceptable
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: Gone
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: Unsupported media type
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: Throttled
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: Internal server error
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - enkelvoudiginformatieobjecten
+      security:
+      - JWT-Claims:
+        - (documenten.lock | documenten.geforceerd-unlock)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UnlockEnkelvoudigInformatieObject'
+        required: true
+    parameters:
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
   /gebruiksrechten:
     get:
       operationId: gebruiksrechten_list
-      description: 'Geef een lijst van gebruiksrechten horend bij informatieobjecten.
-
-
-        Er kan gefiltered worden met querystringparameters.'
+      summary: Geef een lijst van gebruiksrechten horend bij informatieobjecten.
+      description: Er kan gefiltered worden met querystringparameters.
       parameters:
       - name: informatieobject
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde informatieobject
         required: false
         schema:
           type: string
@@ -1406,9 +1895,31 @@ paths:
         - documenten.lezen
     post:
       operationId: gebruiksrechten_create
-      description: "Voeg gebruiksrechten toe voor een informatieobject.\n\n**Opmerkingen**\n\
-        - Het toevoegen van gebruiksrechten zorgt ervoor dat de\n  `indicatieGebruiksrecht`\
-        \ op het informatieobject op `true` gezet wordt."
+      summary: Voeg gebruiksrechten toe voor een informatieobject.
+      description: "**Opmerkingen**\n- Het toevoegen van gebruiksrechten zorgt ervoor\
+        \ dat de\n  `indicatieGebruiksrecht` op het informatieobject op `true` gezet\
+        \ wordt."
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -1676,6 +2187,27 @@ paths:
     put:
       operationId: gebruiksrechten_update
       description: Werk een gebruiksrecht van een informatieobject bij.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1819,6 +2351,27 @@ paths:
     patch:
       operationId: gebruiksrechten_partial_update
       description: Werk een gebruiksrecht van een informatieobject bij.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1961,10 +2514,31 @@ paths:
         $ref: '#/components/requestBodies/Gebruiksrechten'
     delete:
       operationId: gebruiksrechten_delete
-      description: "Verwijder een gebruiksrecht van een informatieobject.\n\n**Opmerkingen**\n\
-        - Indien het laatste gebruiksrecht van een informatieobject verwijderd wordt,\n\
-        \  dan wordt de `indicatieGebruiksrecht` van het informatieobject op `null`\n\
-        \  gezet."
+      summary: Verwijder een gebruiksrecht van een informatieobject.
+      description: "**Opmerkingen**\n- Indien het laatste gebruiksrecht van een informatieobject\
+        \ verwijderd wordt,\n  dan wordt de `indicatieGebruiksrecht` van het informatieobject\
+        \ op `null`\n  gezet."
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -2098,11 +2672,7 @@ paths:
   /objectinformatieobjecten:
     get:
       operationId: objectinformatieobject_list
-      description: 'Geef een lijst van relaties tussen INFORMATIEOBJECTen en andere
-        OBJECTen.
-
-
-        Deze lijst kan gefilterd wordt met querystringparameters.'
+      description: Geef een lijst van relaties tussen OBJECTen en INFORMATIEOBJECTen.
       parameters:
       - name: object
         in: query
@@ -2113,7 +2683,7 @@ paths:
           format: uri
       - name: informatieobject
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde informatieobject
         required: false
         schema:
           type: string
@@ -2248,17 +2818,28 @@ paths:
         - documenten.lezen
     post:
       operationId: objectinformatieobject_create
-      description: "Registreer een INFORMATIEOBJECT bij een OBJECT. Er worden twee\
-        \ types van\nrelaties met andere objecten gerealiseerd:\n\n* INFORMATIEOBJECT\
-        \ behoort bij [OBJECT] en\n* INFORMATIEOBJECT is vastlegging van [OBJECT].\n\
-        \n**Er wordt gevalideerd op**\n- geldigheid informatieobject URL\n- geldigheid\
-        \ object URL\n- de combinatie informatieobject en object moet uniek zijn\n\
-        \n**Opmerkingen**\n- De registratiedatum wordt door het systeem op 'NU' gezet.\
-        \ De `aardRelatie`\n  wordt ook door het systeem gezet.\n- Bij het aanmaken\
-        \ wordt ook in de bron van het OBJECT de gespiegelde\n  relatie aangemaakt,\
-        \ echter zonder de relatie-informatie.\n- Titel, beschrijving en registratiedatum\
-        \ zijn enkel relevant als het om een\n  object van het type ZAAK gaat (aard\
-        \ relatie \"hoort bij\")."
+      description: ''
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -2391,15 +2972,17 @@ paths:
       - JWT-Claims:
         - documenten.aanmaken
       requestBody:
-        $ref: '#/components/requestBodies/ObjectInformatieObject'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ObjectInformatieObject'
+        required: true
     parameters: []
   /objectinformatieobjecten/{uuid}:
     get:
       operationId: objectinformatieobject_read
-      description: 'Geef de details van een relatie tussen een INFORMATIEOBJECT en
-        een ander
-
-        OBJECT.'
+      description: Geef een informatieobject terug wat gekoppeld is aan het huidige
+        object
       responses:
         '200':
           description: ''
@@ -2526,319 +3109,30 @@ paths:
       security:
       - JWT-Claims:
         - documenten.lezen
-    put:
-      operationId: objectinformatieobject_update
-      description: 'Update een INFORMATIEOBJECT bij een OBJECT. Je mag enkel de gegevens
-
-        van de relatie bewerken, en niet de relatie zelf aanpassen.
-
-
-        **Er wordt gevalideerd op**
-
-        - informatieobject URL, object URL en objectType mogen niet veranderen
-
-
-        Titel, beschrijving en registratiedatum zijn enkel relevant als het om een
-
-        object van het type ZAAK gaat (aard relatie "hoort bij").'
-      responses:
-        '200':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ObjectInformatieObject'
-        '400':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ValidatieFout'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '404':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - objectinformatieobjecten
-      security:
-      - JWT-Claims:
-        - documenten.bijwerken
-      requestBody:
-        $ref: '#/components/requestBodies/ObjectInformatieObject'
-    patch:
-      operationId: objectinformatieobject_partial_update
-      description: 'Update een INFORMATIEOBJECT bij een OBJECT. Je mag enkel de gegevens
-
-        van de relatie bewerken, en niet de relatie zelf aanpassen.
-
-
-        **Er wordt gevalideerd op**
-
-        - informatieobject URL, object URL en objectType mogen niet veranderen
-
-
-        Titel, beschrijving en registratiedatum zijn enkel relevant als het om een
-
-        object van het type ZAAK gaat (aard relatie "hoort bij").'
-      responses:
-        '200':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ObjectInformatieObject'
-        '400':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ValidatieFout'
-        '401':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '403':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '404':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '406':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '409':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '410':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '415':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '429':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-        '500':
-          description: ''
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-      tags:
-      - objectinformatieobjecten
-      security:
-      - JWT-Claims:
-        - documenten.bijwerken
-      requestBody:
-        $ref: '#/components/requestBodies/ObjectInformatieObject'
     delete:
       operationId: objectinformatieobject_delete
-      description: Verwijdert de relatie tussen OBJECT en INFORMATIEOBJECT.
+      description: Verwijder een relatie tussen een object en een informatieobject.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -2973,12 +3267,6 @@ servers:
 - url: /api/v1
 components:
   requestBodies:
-    ObjectInformatieObject:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ObjectInformatieObject'
-      required: true
     EnkelvoudigInformatieObjectData:
       content:
         application/json:
@@ -3670,6 +3958,7 @@ components:
             zaak waarin het document een rol speelt.
           type: string
           format: date
+          nullable: true
         verzenddatum:
           title: Verzenddatum
           description: De datum waarop het INFORMATIEOBJECT verzonden is, zoals deze
@@ -3681,6 +3970,7 @@ components:
             waarin het document een rol speelt.
           type: string
           format: date
+          nullable: true
         indicatieGebruiksrecht:
           title: Indicatie gebruiksrecht
           description: Indicatie of er beperkingen gelden aangaande het gebruik van
@@ -3689,6 +3979,7 @@ components:
             gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen
             via de `Gebruiksrechten` resource.
           type: boolean
+          nullable: true
         ondertekening:
           $ref: '#/components/schemas/Ondertekening'
         integriteit:
@@ -3700,6 +3991,13 @@ components:
           format: uri
           maxLength: 200
           minLength: 1
+        lock:
+          title: Lock
+          description: Tijdens het updaten van een document (PATCH, PUT) moet het
+            `lock` veld opgegeven worden. Bij het aanmaken (POST) mag het geen waarde
+            hebben.
+          type: string
+          maxLength: 100
     Fout:
       required:
       - code
@@ -4413,6 +4711,7 @@ components:
             zaak waarin het document een rol speelt.
           type: string
           format: date
+          nullable: true
         verzenddatum:
           title: Verzenddatum
           description: De datum waarop het INFORMATIEOBJECT verzonden is, zoals deze
@@ -4424,6 +4723,7 @@ components:
             waarin het document een rol speelt.
           type: string
           format: date
+          nullable: true
         indicatie_gebruiksrecht:
           title: Indicatie gebruiksrecht
           description: Indicatie of er beperkingen gelden aangaande het gebruik van
@@ -4432,6 +4732,7 @@ components:
             gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen
             via de `Gebruiksrechten` resource.
           type: boolean
+          nullable: true
         ondertekening:
           $ref: '#/components/schemas/Ondertekening'
         integriteit:
@@ -4443,6 +4744,13 @@ components:
           format: uri
           maxLength: 200
           minLength: 1
+        lock:
+          title: Lock
+          description: Tijdens het updaten van een document (PATCH, PUT) moet het
+            `lock` veld opgegeven worden. Bij het aanmaken (POST) mag het geen waarde
+            hebben.
+          type: string
+          maxLength: 100
     Wijzgingen:
       title: Wijzigingen
       type: object
@@ -4589,6 +4897,23 @@ components:
           readOnly: true
         wijzigingen:
           $ref: '#/components/schemas/Wijzgingen'
+    LockEnkelvoudigInformatieObject:
+      type: object
+      properties:
+        lock:
+          title: Lock
+          description: Hash string, wordt gebruikt als ID voor de lock
+          type: string
+          readOnly: true
+          minLength: 1
+    UnlockEnkelvoudigInformatieObject:
+      type: object
+      properties:
+        lock:
+          title: Lock
+          description: Hash string, wordt gebruikt als ID voor de lock
+          type: string
+          maxLength: 100
     Gebruiksrechten:
       required:
       - informatieobject
@@ -4618,6 +4943,7 @@ components:
             van toepassing zijn.
           type: string
           format: date-time
+          nullable: true
         omschrijvingVoorwaarden:
           title: Omschrijving voorwaarden
           description: Omschrijving van de van toepassing zijnde voorwaarden aan het
@@ -4653,29 +4979,3 @@ components:
           enum:
           - besluit
           - zaak
-        aardRelatieWeergave:
-          title: Aard relatie weergave
-          type: string
-          enum:
-          - 'Hoort bij, omgekeerd: kent'
-          - 'Legt vast, omgekeerd: kan vastgelegd zijn als'
-          readOnly: true
-        titel:
-          title: Titel
-          description: De naam waaronder het INFORMATIEOBJECT binnen het OBJECT bekend
-            is.
-          type: string
-          maxLength: 200
-        beschrijving:
-          title: Beschrijving
-          description: Een op het object gerichte beschrijving van de inhoud vanhet
-            INFORMATIEOBJECT.
-          type: string
-        registratiedatum:
-          title: Registratiedatum
-          description: De datum waarop de behandelende organisatie het INFORMATIEOBJECT
-            heeft geregistreerd bij het OBJECT. Geldige waardes zijn datumtijden gelegen
-            op of voor de huidige datum en tijd.
-          type: string
-          format: date-time
-          readOnly: true

--- a/api-specificatie/nrc/openapi.yaml
+++ b/api-specificatie/nrc/openapi.yaml
@@ -1521,7 +1521,7 @@ components:
           format: uri
           maxLength: 200
         filters:
-          description: Comma-separated list of filters of the kanaal
+          description: Komma-gescheiden lijst van filters van het kanaal
           type: array
           items:
             title: Filters

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -168,6 +168,25 @@ paths:
       description: 'Indien geen identificatie gegeven is, dan wordt deze automatisch
 
         gegenereerd.'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -449,7 +468,7 @@ paths:
       parameters:
       - name: zaak
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde zaak
         required: false
         schema:
           type: string
@@ -597,6 +616,25 @@ paths:
         - geldigheid URL naar de ZAAK
 
         - geldigheid URL naar het RESULTAATTYPE'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -869,6 +907,25 @@ paths:
         - geldigheid URL naar de ZAAK
 
         - geldigheid URL naar het RESULTAATTYPE'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1017,6 +1074,25 @@ paths:
         - geldigheid URL naar de ZAAK
 
         - geldigheid URL naar het RESULTAATTYPE'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1160,6 +1236,25 @@ paths:
     delete:
       operationId: resultaat_delete
       description: Verwijder het RESULTAAT van een ZAAK.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -1297,7 +1392,7 @@ paths:
       parameters:
       - name: zaak
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde zaak
         required: false
         schema:
           type: string
@@ -1467,6 +1562,25 @@ paths:
     post:
       operationId: rol_create
       description: Koppel een BETROKKENE aan een ZAAK.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -1754,7 +1868,7 @@ paths:
       parameters:
       - name: zaak
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde zaak
         required: false
         schema:
           type: string
@@ -1903,6 +2017,25 @@ paths:
         \ die aan\n  de zaak gerelateerd zijn\n\n**Opmerkingen**\n- Indien het statustype\
         \ de eindstatus is (volgens het ZTC), dan wordt de\n  zaak afgesloten door\
         \ de einddatum te zetten."
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -2302,6 +2435,25 @@ paths:
     post:
       operationId: zaakobject_create
       description: Registreer een ZAAKOBJECT relatie.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -2672,7 +2824,7 @@ paths:
           type: string
       - name: page
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         required: false
         schema:
           type: integer
@@ -2895,6 +3047,24 @@ paths:
           type: string
           enum:
           - EPSG:4326
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -3051,7 +3221,7 @@ paths:
       parameters:
       - name: page
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         required: false
         schema:
           type: integer
@@ -3454,6 +3624,24 @@ paths:
           type: string
           enum:
           - EPSG:4326
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -3651,6 +3839,24 @@ paths:
           type: string
           enum:
           - EPSG:4326
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -3823,6 +4029,25 @@ paths:
         \ zaak\n- `zaakinformatieobject` - dit moet door-cascaden naar DRCs, zie ook\n\
         \  https://github.com/VNG-Realisatie/gemma-zaken/issues/791 (TODO)\n- `klantcontact`\
         \ - alle klantcontacten bij een zaak"
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -4082,6 +4307,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - audittrails.lezen
     parameters:
     - name: zaak_uuid
       in: path
@@ -4217,6 +4445,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - zaken
+      security:
+      - JWT-Claims:
+        - audittrails.lezen
     parameters:
     - name: uuid
       in: path
@@ -4355,6 +4586,25 @@ paths:
     post:
       operationId: zaakinformatieobject_create
       description: ''
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -4634,6 +4884,25 @@ paths:
     delete:
       operationId: zaakinformatieobject_delete
       description: Verwijder een relatie tussen een zaak en een informatieobject
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -4894,6 +5163,25 @@ paths:
     post:
       operationId: zaakeigenschap_create
       description: Registreer een eigenschap van een ZAAK.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Application that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identifier of the user that performs request
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Explanation why the request is done
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''

--- a/api-specificatie/zrc/openapi.yaml
+++ b/api-specificatie/zrc/openapi.yaml
@@ -171,19 +171,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -619,19 +621,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -910,19 +914,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -1077,19 +1083,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -1239,19 +1247,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -1565,19 +1575,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -2020,19 +2032,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -2312,6 +2326,955 @@ paths:
       schema:
         type: string
         format: uuid
+  /zaakinformatieobjecten:
+    get:
+      operationId: zaakinformatieobject_list
+      summary: Geef een lijst van relaties tussen INFORMATIEOBJECTen en ZAAKen.
+      description: Deze lijst kan gefilterd wordt met querystringparameters.
+      parameters:
+      - name: zaak
+        in: query
+        description: URL naar de/het gerelateerde zaak
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: informatieobject
+        in: query
+        description: URL-referentie naar het informatieobject in het DRC, waar ook
+          de relatieinformatie opgevraagd kan worden.
+        required: false
+        schema:
+          type: string
+          format: uri
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - zaakinformatieobjecten
+      security:
+      - JWT-Claims:
+        - zaken.lezen
+    post:
+      operationId: zaakinformatieobject_create
+      summary: 'Registreer een INFORMATIEOBJECT bij een ZAAK. Er worden twee types
+        van
+
+        relaties met andere objecten gerealiseerd:'
+      description: "**Er wordt gevalideerd op**\n- geldigheid zaak URL\n- geldigheid\
+        \ informatieobject URL\n- de combinatie informatieobject en zaak moet uniek\
+        \ zijn\n\n**Opmerkingen**\n- De registratiedatum wordt door het systeem op\
+        \ 'NU' gezet. De `aardRelatie`\n  wordt ook door het systeem gezet.\n- Bij\
+        \ het aanmaken wordt ook in het DRC de gespiegelde relatie aangemaakt,\n \
+        \ echter zonder de relatie-informatie.\n\n\nRegistreer welk(e) INFORMATIEOBJECT(en)\
+        \ een ZAAK kent.\n\n**Er wordt gevalideerd op**\n- geldigheid informatieobject\
+        \ URL\n- uniek zijn van relatie ZAAK-INFORMATIEOBJECT"
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
+      responses:
+        '201':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - zaakinformatieobjecten
+      security:
+      - JWT-Claims:
+        - zaken.aanmaken
+      requestBody:
+        $ref: '#/components/requestBodies/ZaakInformatieObject'
+    parameters: []
+  /zaakinformatieobjecten/{uuid}:
+    get:
+      operationId: zaakinformatieobject_read
+      description: Geef de details van een relatie tussen een INFORMATIEOBJECT en
+        een ZAAK.
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - zaakinformatieobjecten
+      security:
+      - JWT-Claims:
+        - zaken.lezen
+    put:
+      operationId: zaakinformatieobject_update
+      description: 'Update een INFORMATIEOBJECT bij een ZAAK. Je mag enkel de gegevens
+
+        van de relatie bewerken, en niet de relatie zelf aanpassen.
+
+
+        **Er wordt gevalideerd op**
+
+        - informatieobject URL en zaak URL mogen niet veranderen'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - zaakinformatieobjecten
+      security:
+      - JWT-Claims:
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      requestBody:
+        $ref: '#/components/requestBodies/ZaakInformatieObject'
+    patch:
+      operationId: zaakinformatieobject_partial_update
+      description: 'Update een INFORMATIEOBJECT bij een ZAAK. Je mag enkel de gegevens
+
+        van de relatie bewerken, en niet de relatie zelf aanpassen.
+
+
+        **Er wordt gevalideerd op**
+
+        - informatieobject URL en zaak URL mogen niet veranderen'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+        '400':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - zaakinformatieobjecten
+      security:
+      - JWT-Claims:
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      requestBody:
+        $ref: '#/components/requestBodies/ZaakInformatieObject'
+    delete:
+      operationId: zaakinformatieobject_delete
+      description: 'Verwijdert de relatie tussen ZAAK en INFORMATIEOBJECT. De gespiegelde
+
+        relatie in het DRC wordt door het ZRC verwijderd - als consumer hoef je
+
+        niets te doen.'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+      tags:
+      - zaakinformatieobjecten
+      security:
+      - JWT-Claims:
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken | zaken.verwijderen)
+    parameters:
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
   /zaakobjecten:
     get:
       operationId: zaakobject_list
@@ -2438,19 +3401,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -3049,19 +4014,21 @@ paths:
           - EPSG:4326
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -3626,19 +4593,21 @@ paths:
           - EPSG:4326
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -3841,19 +4810,21 @@ paths:
           - EPSG:4326
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -4032,19 +5003,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -4463,10 +5436,10 @@ paths:
       schema:
         type: string
         format: uuid
-  /zaken/{zaak_uuid}/informatieobjecten:
+  /zaken/{zaak_uuid}/besluiten:
     get:
-      operationId: zaakinformatieobject_list
-      description: Geef een lijst van relaties tussen ZAAKen en INFORMATIEOBJECTen.
+      operationId: zaakbesluit_list
+      description: Provides a list of relations between Zaak and Besluit objects
       responses:
         '200':
           description: ''
@@ -4481,7 +5454,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ZaakInformatieObject'
+                  $ref: '#/components/schemas/ZaakBesluit'
         '401':
           description: ''
           headers:
@@ -4584,24 +5557,26 @@ paths:
       - JWT-Claims:
         - zaken.lezen
     post:
-      operationId: zaakinformatieobject_create
+      operationId: zaakbesluit_create
       description: ''
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -4622,7 +5597,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ZaakInformatieObject'
+                $ref: '#/components/schemas/ZaakBesluit'
         '400':
           description: ''
           headers:
@@ -4740,7 +5715,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ZaakInformatieObject'
+              $ref: '#/components/schemas/ZaakBesluit'
         required: true
     parameters:
     - name: zaak_uuid
@@ -4750,11 +5725,10 @@ paths:
       schema:
         type: string
         format: uuid
-  /zaken/{zaak_uuid}/informatieobjecten/{uuid}:
+  /zaken/{zaak_uuid}/besluiten/{uuid}:
     get:
-      operationId: zaakinformatieobject_read
-      description: Geef een informatieobject terug wat gekoppeld is aan de huidige
-        zaak
+      operationId: zaakbesluit_read
+      description: Return Besluit which is linked with the current Zaak object
       responses:
         '200':
           description: ''
@@ -4767,7 +5741,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ZaakInformatieObject'
+                $ref: '#/components/schemas/ZaakBesluit'
         '401':
           description: ''
           headers:
@@ -4882,24 +5856,26 @@ paths:
       - JWT-Claims:
         - zaken.lezen
     delete:
-      operationId: zaakinformatieobject_delete
-      description: Verwijder een relatie tussen een zaak en een informatieobject
+      operationId: zaakbesluit_delete
+      description: Remove relations between Zaak and Besluit objects
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -5166,19 +6142,21 @@ paths:
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
-        description: Application that performs request
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-NLX-Request-User-Id
         in: header
-        description: Identifier of the user that performs request
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
         required: false
         schema:
           type: string
       - name: X-Audit-Toelichting
         in: header
-        description: Explanation why the request is done
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
         required: false
         schema:
           type: string
@@ -5482,6 +6460,12 @@ components:
           schema:
             $ref: '#/components/schemas/Resultaat'
       required: true
+    ZaakInformatieObject:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ZaakInformatieObject'
+      required: true
     Zaak:
       content:
         application/json:
@@ -5742,6 +6726,55 @@ components:
             de status van een zaak.
           type: string
           maxLength: 1000
+    ZaakInformatieObject:
+      required:
+      - informatieobject
+      - zaak
+      type: object
+      properties:
+        url:
+          title: Url
+          type: string
+          format: uri
+          readOnly: true
+        informatieobject:
+          title: Informatieobject
+          description: URL-referentie naar het informatieobject in het DRC, waar ook
+            de relatieinformatie opgevraagd kan worden.
+          type: string
+          format: uri
+          maxLength: 1000
+          minLength: 1
+        zaak:
+          title: Zaak
+          type: string
+          format: uri
+        aardRelatieWeergave:
+          title: Aard relatie weergave
+          type: string
+          enum:
+          - 'Hoort bij, omgekeerd: kent'
+          - 'Legt vast, omgekeerd: kan vastgelegd zijn als'
+          readOnly: true
+        titel:
+          title: Titel
+          description: De naam waaronder het INFORMATIEOBJECT binnen het OBJECT bekend
+            is.
+          type: string
+          maxLength: 200
+        beschrijving:
+          title: Beschrijving
+          description: Een op het object gerichte beschrijving van de inhoud vanhet
+            INFORMATIEOBJECT.
+          type: string
+        registratiedatum:
+          title: Registratiedatum
+          description: De datum waarop de behandelende organisatie het INFORMATIEOBJECT
+            heeft geregistreerd bij het OBJECT. Geldige waardes zijn datumtijden gelegen
+            op of voor de huidige datum en tijd.
+          type: string
+          format: date-time
+          readOnly: true
     ZaakObject:
       required:
       - zaak
@@ -6461,9 +7494,9 @@ components:
           readOnly: true
         wijzigingen:
           $ref: '#/components/schemas/Wijzgingen'
-    ZaakInformatieObject:
+    ZaakBesluit:
       required:
-      - informatieobject
+      - besluit
       type: object
       properties:
         url:
@@ -6471,9 +7504,9 @@ components:
           type: string
           format: uri
           readOnly: true
-        informatieobject:
-          title: Informatieobject
-          description: URL-referentie naar het informatieobject in het DRC, waar ook
+        besluit:
+          title: Besluit
+          description: URL-referentie naar het informatieobject in het BRC, waar ook
             de relatieinformatie opgevraagd kan worden.
           type: string
           format: uri

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -2039,14 +2039,14 @@ paths:
       parameters:
       - name: zaaktype
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde zaaktype
         required: false
         schema:
           type: string
           format: uri
       - name: pagina
         in: query
-        description: A page number within the paginated result set.
+        description: Een pagina binnen de gepagineerde set resultaten.
         required: false
         schema:
           type: integer
@@ -2353,14 +2353,14 @@ paths:
       parameters:
       - name: zaaktype
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde zaaktype
         required: false
         schema:
           type: string
           format: uri
       - name: informatieObjectType
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde informatie_object_type
         required: false
         schema:
           type: string

--- a/api-specificatie/ztc/openapi.yaml
+++ b/api-specificatie/ztc/openapi.yaml
@@ -2930,6 +2930,7 @@ components:
       - referentieproces
       - catalogus
       - gerelateerdeZaaktypen
+      - beginGeldigheid
       type: object
       properties:
         url:
@@ -3152,6 +3153,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ZaakTypenRelatie'
+        beginGeldigheid:
+          title: Begin geldigheid
+          description: De datum waarop het is ontstaan.
+          type: string
+          format: date
+        eindeGeldigheid:
+          title: Einde geldigheid
+          description: De datum waarop het is opgeheven.
+          type: string
+          format: date
     EigenschapSpecificatie:
       title: Specificatie
       required:


### PR DESCRIPTION
# API specificatie aanpassing

Deze aanpassingen zijn nodig voor de release candidate.

In grote lijnen:

* relatierichting tussen documenten en zaken/besluiten omgekeerd
* besluiten/zaken relatie heeft nu ook een cross-reference in ZRC
* Nederlandse vertaling in API-specificaties

**Userstories**
* Zie: [PR vernietigen DRC/BRC](https://github.com/VNG-Realisatie/gemma-zaken/issues/817)
* Zie: [Versioneren zaaktypen](https://github.com/VNG-Realisatie/gemma-zaken/issues/982)
* Zie: [Toegang tot besluit vanuit Zaak-API](https://github.com/VNG-Realisatie/gemma-zaken/issues/775)
* Zie: [Omkeren richting relatie](https://github.com/VNG-Realisatie/gemma-zaken/issues/979)

## ZRC

**Links**

* [API documentatie](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/update-api-specs/api-specificatie/zrc/openapi.yaml)

**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Audit-gerelateerde headers toegevoegd
* `ZaakInformatieObject` is niet langer een subresource van `Zaak`, maar is
  verhuisd naar de root van de API
* `ZaakInformatieObject` moet nu door consumers aangemaakt worden in plaats
  van door het DRC _en_ bevat de relatieinformatie die voordien in het DRC lag
* Er kan nu ook gefiltered worden op `ZaakInformatieObject.zaak`
* Vertalingen
* Autorisatie op audittrails toegevoegd
* `ZaakBesluit` resource toegevoegd die toelaat om vanaf de zaak de besluiten
  terug te vinden. Deze relatie wordt door het BRC aangemaakt

**Kanttekeningen**

* De `ZaakInformatieObject` wijzigingen zijn een breaking change
* De relatie zelf (`zaak` + `informatieobject`) mag nooit wijzigen

## DRC

**Links**

* [API documentatie](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/update-api-specs/api-specificatie/drc/openapi.yaml)

**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* `ObjectInformatieObject` mag niet meer door consumers zelf aangemaakt worden,
  maar moet door BRC respectievelijk ZRC gebeuren.
* Relatie-informatie is van `ObjectInformatieObject` verwijderd
* Vertalingen van Engels naar Nederlands in API-spec
* Audit-gerelateerde headers toegevoegd
* Bestand-download (`EnkelvoudigInformatieObject.inhoud` url) is nu ook 
  beschermd met autorisatiemechanisme, scope hiervoor is opgenomen en het 
  endpoint toegevoegd aan de API spec.
* Locken van `EnkelvoudigInformatieObject` toegevoegd. Een lock is nodig voor 
  je mag bewerken (`update`, `partial_update`). Bij het locken krijg je een 
  lock-id terug die je moet meesturen bij de bewerkoperaties
* Unlock operatie op `EnkelvoudigInformatieObject` toegevoegd. Hierbij moet je
  het lock-ID meesturen.
* Scope toegevoegd die beheerders toelaat om gefoceerd documenten te unlocken.
* Autorisatie op audittrails toegevoegd

**Kanttekeningen**

* Breaking change in het gedrag van `ObjectInformatieObject`
* Locken is nodig voor het updaten van de `inhoud` _en_ voor de meta-gegevens
  van een `InformatieObject`, ook als de inhoud niet wijzigt.
* Er worden (nog) geen notificaties verstuurd bij het (un)locken van documenten

## ZTC

**Links**

* [API documentatie](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/update-api-specs/api-specificatie/ztc/openapi.yaml)

**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Vertalingen
* Toevoeging van `Zaaktype.beginGeldigheid` en `Zaaktype.eindeGeldigheid`

**Kanttekeningen**

* In de beheeromgeving is het nu toegelaten om zaaktypen met dezelfde 
  omschrijving/identificatie te maken MITS deze niet overlappen in 
  geldigheidsperiode

## BRC

**Links**

* [API documentatie](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/update-api-specs/api-specificatie/brc/openapi.yaml)

**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Vertalingen
* Resource `BesluitInformatieObject` is niet langer een subresource van 
  `Besluit`, maar wordt nu op de root ontsloten
* Filteren op `BesluitInformatieObject.besluit` en 
  `BesluitInformatieObject.informatieobject` is mogelijk
* Resource `BesluitInformatieObject` moet nu door consumer in BRC aangemaakt 
  worden, in plaats van `ObjectInformatieObject` in DRC aan te maken
* Autorisatie op audittrails toegevoegd

**Kanttekeningen**

* `BesluitInformatieObject` relatie-omkering is een breaking change
* Het BRC synchroniseert met het overeenkomstige DRC en maakt onder water het
  `ObjectInformatieObject` aan.

## NRC

**Links**

* [API documentatie](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/update-api-specs/api-specificatie/nrc/openapi.yaml)

**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Vertalingen

## AC

**Links**

* [API documentatie](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/feature/update-api-specs/api-specificatie/ac/openapi.yaml)

**Wijzigingen**
Deze uitbreiding (en aanpassing) op de spec heeft de volgende
aanpassingen:

* Vertalingen

# Review checklist

Aftikken van reviewelementen

- [x] Build slaagt
- [ ] Wijzigingen duidelijk omschreven en akkoord
- [ ] Voldoet aan RGBZ of afwijkingen zijn akkoord
- [ ] Voldoet aan GEMMA architectuur of afwijkingen zijn akkoord
