### PR TITLE
:bug: Moved media to private-media as per Django config

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - DB_HOST=drc_db
       - IS_HTTPS=0
     volumes:
-      - drc_media:/app/media
+      - drc_media:/app/private-media
     depends_on:
       - drc_db
 

--- a/infra/drc/web.yml
+++ b/infra/drc/web.yml
@@ -38,7 +38,7 @@ spec:
             value: <REDACTED>
         volumeMounts:
           - name: media
-            mountPath: "/app/media"
+            mountPath: "/app/private-media"
 
 ---
 


### PR DESCRIPTION
I noticed the DRC Django configuration uses "private-media" now. I adjusted the mount accordingly.

Also adjusted in k8s.