### PR TITLE
:pencil: Replaced rebilly with redocly.

### DIFF
--- a/docs/_content/overige/bronnen.md
+++ b/docs/_content/overige/bronnen.md
@@ -51,4 +51,4 @@ voor informatiemodellen](https://docs.geostandaarden.nl/mim/def-st-mim10-2017061
 - [Thoughts on RESTful API Design](https://restful-api-design.readthedocs.io/en/latest/) Lessons learnt from designing the Red Hat Enterprise Virtualization API
 - [JSON Schema Validator](https://json-schema-validator.herokuapp.com/)
 - [Render OAS as Swagger docs](https://petstore.swagger.io/)
-- [Render OAS as ReDoc docs](http://rebilly.github.io/ReDoc/)
+- [Render OAS as ReDoc docs](https://redocly.github.io/redoc/)

--- a/docs/_content/overige/documentatie.md
+++ b/docs/_content/overige/documentatie.md
@@ -53,7 +53,7 @@ Dit document beantwoordt de volgende vragen:
 
 **Voorbeelden**
 
-* [Petstore ReDoc documentatie](https://rebilly.github.io/ReDoc/)
+* [Petstore ReDoc documentatie](https://redocly.github.io/redoc/)
 * [Petstore Swagger documentatie](http://petstore.swagger.io/)
 * [GMail API documentatie](https://developers.google.com/gmail/api/v1/reference/?hl=nl)
 

--- a/docs/_content/standaard/apis/nrc.md
+++ b/docs/_content/standaard/apis/nrc.md
@@ -20,7 +20,7 @@ Het ondersteunt:
 ![Jenkins][jenkins]
 
 * [API-specificatie (provider)](https://ref.tst.vng.cloud/nrc/api/v1/schema/)
-* [API-specificatie (consumer)](https://rebilly.github.io/ReDoc/?url=https://ref.tst.vng.cloud/api-specificatie/nrc/consumer-api/openapi.yaml)
+* [API-specificatie (consumer)](https://redocly.github.io/redoc/?url=https://ref.tst.vng.cloud/api-specificatie/nrc/consumer-api/openapi.yaml)
 * [Referentie implementatie](https://github.com/VNG-Realisatie/gemma-notificatiecomponent)
 * Communiceren met dit component (client)
 * Zelf dit component implementeren (server)

--- a/docs/_content/standaard/index.md
+++ b/docs/_content/standaard/index.md
@@ -5,7 +5,7 @@ layout: subjects
 
 De ZGW API Standaard bestaat uit 2 delen:
 
-* [Standaard ("in ontwikkeling")](standaard) als startpunt om de APIs te 
+* [Standaard ("in ontwikkeling")](standaard) als startpunt om de APIs te
   implementeren of te gebruiken.
 * [API specificaties](apis/index) met alle beschikbare resources en attributen.
 
@@ -17,11 +17,10 @@ Hieronder de directe links naar alle Open API specificaties (OAS):
 * [Besluiten API specificatie](https://ref.tst.vng.cloud/brc/api/v1/schema/)
 * [Autorisaties API specificatie](https://ref.tst.vng.cloud/ac/api/v1/schema/)
 * [Notificaties API specificatie](https://ref.tst.vng.cloud/nrc/api/v1/schema/)
-  * [Notificaties API specificatie voor consumers](https://rebilly.github.io/ReDoc/?url=https://ref.tst.vng.cloud/api-specificatie/nrc/consumer-api/openapi.yaml)
-  
+* [Notificaties API specificatie voor consumers](https://redocly.github.io/redoc/?url=https://ref.tst.vng.cloud/api-specificatie/nrc/consumer-api/openapi.yaml)
+
 In de figuur hieronder is een overzicht weergegeven van de API's voor Zaakgericht werken. De Catalogi API en Zaken API zijn puur voor zaakgericht werken bedoeld, en hebben geen functie daarbuiten. De Documenten API en Besluiten API zullen ook buiten zaakgericht werken toepassingen krijgen. Immers, niet alle documenten zijn zaakgericht en niet alle besluiten zullen in de context van een zaak worden genomen. Denk bij het laatste bijv. aan raadsbesluiten.
 
 Naast deze API zijn er nog een aantal API’s ontwikkeld ter ondersteuning, t.w. Notificaties API, Autorisatie API en de Referentielijsten API.
 
 ![overzicht API's](apis.png)
-


### PR DESCRIPTION
Rebilly redirected but without preserving the query parameter, so any link to Rebilly ended up at petstore.