### PR TITLE
Document API-versions compatibility

### DIFF
--- a/api-specificatie/brc/openapi.yaml
+++ b/api-specificatie/brc/openapi.yaml
@@ -195,6 +195,27 @@ paths:
         - geldigheid zaak URL
 
         - datum in het verleden of nu'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -446,6 +467,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - audittrails.lezen
     parameters:
     - name: besluit_uuid
       in: path
@@ -581,6 +605,9 @@ paths:
                 $ref: '#/components/schemas/Fout'
       tags:
       - besluiten
+      security:
+      - JWT-Claims:
+        - audittrails.lezen
     parameters:
     - name: besluit_uuid
       in: path
@@ -742,6 +769,27 @@ paths:
         - geldigheid zaak URL
 
         - datum in het verleden of nu'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -898,6 +946,27 @@ paths:
         - geldigheid zaak URL
 
         - datum in het verleden of nu'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1043,6 +1112,27 @@ paths:
       description: "Verwijdert een BESLUIT, samen met alle gerelateerde resources\
         \ binnen deze API.\n\n**De gerelateerde resources zijn**\n- `BesluitInformatieObject`\
         \ - de relaties van het Besluit naar de\n  informatieobjecten"
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -1182,7 +1272,7 @@ paths:
       parameters:
       - name: besluit
         in: query
-        description: URL to the related resource
+        description: URL naar de/het gerelateerde besluit
         required: false
         schema:
           type: string
@@ -1335,6 +1425,27 @@ paths:
         \n\nRegistreer welk(e) INFORMATIEOBJECT(en) een BESLUIT kent.\n\n**Er wordt\
         \ gevalideerd op**\n- geldigheid informatieobject URL\n- uniek zijn van relatie\
         \ BESLUIT-INFORMATIEOBJECT"
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '201':
           description: ''
@@ -1610,6 +1721,27 @@ paths:
         **Er wordt gevalideerd op**
 
         - informatieobject URL en besluit URL mogen niet veranderen'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1760,6 +1892,27 @@ paths:
         **Er wordt gevalideerd op**
 
         - informatieobject URL en besluit URL mogen niet veranderen'
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1903,6 +2056,27 @@ paths:
     delete:
       operationId: besluitinformatieobject_delete
       description: Verwijdert de relatie tussen BESLUIT en INFORMATIEOBJECT.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -2285,6 +2459,7 @@ components:
       - hoofdObject
       - resource
       - resourceUrl
+      - resourceWeergave
       - wijzigingen
       type: object
       properties:
@@ -2402,6 +2577,12 @@ components:
           title: Toelichting
           description: Toelichting waarom de handeling is uitgevoerd
           type: string
+        resourceWeergave:
+          title: Resource weergave
+          description: Vriendelijke identificatie van het object
+          type: string
+          maxLength: 200
+          minLength: 1
         aanmaakdatum:
           title: Aanmaakdatum
           description: De datum waarop de handeling is gedaan

--- a/docs/_content/ontwikkelaars/api-compatibiliteit.md
+++ b/docs/_content/ontwikkelaars/api-compatibiliteit.md
@@ -1,0 +1,53 @@
+---
+title: "Aan de slag"
+date: '19-06-2019'
+---
+
+Elke API-specificatie heeft zijn eigen versie, wat voor
+compatibiliteitsproblemen kan zorgen bij het combineren van APIs.
+
+We vatten hier samen welke versies van APIs compatibel zijn met welke versies
+van andere APIs. Indien er geen range opgegeven is, dan betreft het de minimale
+versie van een API.
+
+
+## Autorisaties API (AC)
+
+| Eigen versie      | NRC     | ZRC | DRC | ZTC | BRC |
+|-------------------|---------|-----|-----|-----|-----|
+| `0.2.x` - `0.3.x` | `0.5.x` | -   | -   | -   | -   |
+
+
+## Notificaties API (NRC)
+
+| Eigen versie      | AC      | ZRC | DRC | ZTC | BRC |
+|-------------------|---------|-----|-----|-----|-----|
+| `0.6.0` - `0.7.x` | `0.2.3` | -   | -   | -   | -   |
+
+
+## Zaken API (ZRC)
+
+| Eigen versie | AC      | NRC     | DRC      | ZTC      | BRC      |
+|--------------|---------|---------|----------|----------|----------|
+| `0.17.0`     | `0.2.3` | `0.6.0` | `0.13.0` | `0.11.1` | `0.11.1` |
+
+
+## Documenten API (DRC)
+
+| Eigen versie | AC       | NRC      | ZRC       | ZTC       | BRC       |
+|--------------|----------|----------|-----------|-----------|-----------|
+| `0.14.0`     | `0.2.3`  | `0.6.0`  | `0.17.0`  | `0.10.0`  | `0.11.3`  |
+
+
+## Catalogi API (ZTC)
+
+| Eigen versie | AC       | NRC      | ZRC | DRC | BRC |
+|--------------|----------|----------|-----|-----|-----|
+| `0.14.0`     | `0.2.3`  | `0.6.0`  | -   | -   | -   |
+
+
+## Besluiten API (BRC)
+
+| Eigen versie | AC       | NRC      | ZRC       | DRC       | ZTC      |
+|--------------|----------|----------|-----------|-----------|----------|
+| `0.11.1`     | `0.2.3`  | `0.6.0`  | `0.16.0`  | `0.14.0`  | `0.2.0`  |


### PR DESCRIPTION
Straks wordt alles simpelweg 1.0.0, maar daarna gaat er natuurlijk wel wat spelen van API X heeft minimaal versie `foo` van API Y nodig etc.