### PR TITLE
Updates to 1.0.x versions of ZTC & BRC

### DIFF
--- a/api-specificatie/brc/1.0.x/openapi.yaml
+++ b/api-specificatie/brc/1.0.x/openapi.yaml
@@ -303,7 +303,9 @@ paths:
 
         - geldigheid `zaak` URL
 
-        - `datum` in het verleden of nu'
+        - `datum` in het verleden of nu
+
+        - publicatie `besluittype` - `concept` moet `false` zijn'
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -878,7 +880,9 @@ paths:
 
         - geldigheid `zaak` URL
 
-        - `datum` in het verleden of nu'
+        - `datum` in het verleden of nu
+
+        - publicatie `besluittype` - `concept` moet `false` zijn'
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -1053,7 +1057,9 @@ paths:
 
         - geldigheid `zaak` URL
 
-        - `datum` in het verleden of nu'
+        - `datum` in het verleden of nu
+
+        - publicatie `besluittype` - `concept` moet `false` zijn'
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header

--- a/api-specificatie/ztc/1.0.x/openapi.yaml
+++ b/api-specificatie/ztc/1.0.x/openapi.yaml
@@ -60,7 +60,7 @@ paths:
         schema:
           type: string
           format: uri
-      - name: zaaktypes
+      - name: zaaktypen
         in: query
         description: ZAAKTYPE met ZAAKen die relevant kunnen zijn voor dit BESLUITTYPE
         required: false
@@ -236,7 +236,7 @@ paths:
       - besluittypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: besluittype_create
       summary: Maak een BESLUITTYPE aan.
@@ -373,7 +373,7 @@ paths:
       - besluittypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /besluittypen/{uuid}:
     get:
@@ -505,7 +505,7 @@ paths:
       - besluittypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: besluittype_update
       summary: Werk een BESLUITTYPE in zijn geheel bij.
@@ -652,7 +652,7 @@ paths:
       - besluittypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: besluittype_partial_update
       summary: Werk een BESLUITTYPE deels bij.
@@ -797,7 +797,7 @@ paths:
       - besluittypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: besluittype_delete
       summary: Verwijder een BESLUITTYPE.
@@ -923,7 +923,7 @@ paths:
       - besluittypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -964,7 +964,7 @@ paths:
       - besluittypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters:
     - name: uuid
       in: path
@@ -1154,7 +1154,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: catalogus_create
       summary: Maak een CATALOGUS aan.
@@ -1295,7 +1295,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /catalogussen/{uuid}:
     get:
@@ -1427,7 +1427,7 @@ paths:
       - catalogussen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     parameters:
     - name: uuid
       in: path
@@ -1613,7 +1613,7 @@ paths:
       - eigenschappen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: eigenschap_create
       summary: Maak een EIGENSCHAP aan.
@@ -1753,7 +1753,7 @@ paths:
       - eigenschappen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /eigenschappen/{uuid}:
     get:
@@ -1885,7 +1885,7 @@ paths:
       - eigenschappen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: eigenschap_update
       summary: Werk een EIGENSCHAP in zijn geheel bij.
@@ -2031,7 +2031,7 @@ paths:
       - eigenschappen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: eigenschap_partial_update
       summary: Werk een EIGENSCHAP deels bij.
@@ -2177,7 +2177,7 @@ paths:
       - eigenschappen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: eigenschap_delete
       summary: Verwijder een EIGENSCHAP.
@@ -2306,7 +2306,7 @@ paths:
       - eigenschappen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -2492,7 +2492,7 @@ paths:
       - informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: informatieobjecttype_create
       summary: Maak een INFORMATIEOBJECTTYPE aan.
@@ -2629,7 +2629,7 @@ paths:
       - informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /informatieobjecttypen/{uuid}:
     get:
@@ -2761,7 +2761,7 @@ paths:
       - informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: informatieobjecttype_update
       summary: Werk een INFORMATIEOBJECTTYPE in zijn geheel bij.
@@ -2908,7 +2908,7 @@ paths:
       - informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: informatieobjecttype_partial_update
       summary: Werk een INFORMATIEOBJECTTYPE deels bij.
@@ -3055,7 +3055,7 @@ paths:
       - informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: informatieobjecttype_delete
       summary: Verwijder een INFORMATIEOBJECTTYPE.
@@ -3184,7 +3184,7 @@ paths:
       - informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -3225,7 +3225,7 @@ paths:
       - informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters:
     - name: uuid
       in: path
@@ -3411,7 +3411,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: resultaattype_create
       summary: Maak een RESULTAATTYPE aan.
@@ -3551,7 +3551,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /resultaattypen/{uuid}:
     get:
@@ -3683,7 +3683,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: resultaattype_update
       summary: Werk een RESULTAATTYPE in zijn geheel bij.
@@ -3830,7 +3830,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: resultaattype_partial_update
       summary: Werk een RESULTAATTYPE deels bij.
@@ -3976,7 +3976,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: resultaattype_delete
       summary: Verwijder een RESULTAATTYPE.
@@ -4105,7 +4105,7 @@ paths:
       - resultaattypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -4306,7 +4306,7 @@ paths:
       - roltypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: roltype_create
       summary: Maak een ROLTYPE aan.
@@ -4446,7 +4446,7 @@ paths:
       - roltypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /roltypen/{uuid}:
     get:
@@ -4578,7 +4578,7 @@ paths:
       - roltypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: roltype_update
       summary: Werk een ROLTYPE in zijn geheel bij.
@@ -4724,7 +4724,7 @@ paths:
       - roltypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: roltype_partial_update
       summary: Werk een ROLTYPE deels bij.
@@ -4870,7 +4870,7 @@ paths:
       - roltypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: roltype_delete
       summary: Verwijder een ROLTYPE.
@@ -4999,7 +4999,7 @@ paths:
       - roltypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -5184,7 +5184,7 @@ paths:
       - statustypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: statustype_create
       summary: Maak een STATUSTYPE aan.
@@ -5324,7 +5324,7 @@ paths:
       - statustypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /statustypen/{uuid}:
     get:
@@ -5456,7 +5456,7 @@ paths:
       - statustypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: statustype_update
       summary: Werk een STATUSTYPE in zijn geheel bij.
@@ -5602,7 +5602,7 @@ paths:
       - statustypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: statustype_partial_update
       summary: Werk een STATUSTYPE deels bij.
@@ -5748,7 +5748,7 @@ paths:
       - statustypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: statustype_delete
       summary: Verwijder een STATUSTYPE.
@@ -5877,7 +5877,7 @@ paths:
       - statustypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -6080,7 +6080,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: zaakinformatieobjecttype_create
       summary: Maak een ZAAKTYPE-INFORMATIEOBJECTTYPE relatie aan.
@@ -6225,7 +6225,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /zaaktype-informatieobjecttypen/{uuid}:
     get:
@@ -6357,7 +6357,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: zaakinformatieobjecttype_update
       summary: Werk een ZAAKTYPE-INFORMATIEOBJECTTYPE relatie in zijn geheel bij.
@@ -6509,7 +6509,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: zaakinformatieobjecttype_partial_update
       summary: Werk een ZAAKTYPE-INFORMATIEOBJECTTYPE relatie deels bij.
@@ -6661,7 +6661,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: zaakinformatieobjecttype_delete
       summary: Verwijder een ZAAKTYPE-INFORMATIEOBJECTTYPE relatie.
@@ -6795,7 +6795,7 @@ paths:
       - zaaktype-informatieobjecttypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -6819,10 +6819,11 @@ paths:
           format: uri
       - name: identificatie
         in: query
-        description: ''
+        description: Unieke identificatie van het ZAAKTYPE binnen de CATALOGUS waarin
+          het ZAAKTYPE voorkomt.
         required: false
         schema:
-          type: number
+          type: string
       - name: trefwoorden
         in: query
         description: Multiple values may be separated by commas.
@@ -6992,7 +6993,7 @@ paths:
       - zaaktypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     post:
       operationId: zaaktype_create
       summary: Maak een ZAAKTYPE aan.
@@ -7134,7 +7135,7 @@ paths:
       - zaaktypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters: []
   /zaaktypen/{uuid}:
     get:
@@ -7266,7 +7267,7 @@ paths:
       - zaaktypen
       security:
       - JWT-Claims:
-        - zaaktypes.lezen
+        - catalogi.lezen
     put:
       operationId: zaaktype_update
       summary: Werk een ZAAKTYPE in zijn geheel bij.
@@ -7418,7 +7419,7 @@ paths:
       - zaaktypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     patch:
       operationId: zaaktype_partial_update
       summary: Werk een ZAAKTYPE deels bij.
@@ -7568,7 +7569,7 @@ paths:
       - zaaktypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     delete:
       operationId: zaaktype_delete
       summary: Verwijder een ZAAKTYPE.
@@ -7694,7 +7695,7 @@ paths:
       - zaaktypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - (catalogi.schrijven | catalogi.geforceerd-verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -7733,7 +7734,7 @@ paths:
       - zaaktypen
       security:
       - JWT-Claims:
-        - zaaktypes.schrijven
+        - catalogi.schrijven
     parameters:
     - name: uuid
       in: path
@@ -7803,7 +7804,7 @@ components:
     BesluitType:
       required:
       - catalogus
-      - zaaktypes
+      - zaaktypen
       - publicatieIndicatie
       - informatieobjecttypen
       - beginGeldigheid
@@ -7823,7 +7824,7 @@ components:
           description: URL-referentie naar de CATALOGUS waartoe dit BESLUITTYPE behoort.
           type: string
           format: uri
-        zaaktypes:
+        zaaktypen:
           description: ZAAKTYPE met ZAAKen die relevant kunnen zijn voor dit BESLUITTYPE
           type: array
           items:
@@ -8570,7 +8571,7 @@ components:
           title: Omschrijving
           description: Omschrijving van de aard van de ROL.
           type: string
-          maxLength: 20
+          maxLength: 100
           minLength: 1
         omschrijvingGeneriek:
           title: Omschrijving generiek
@@ -8777,7 +8778,6 @@ components:
           maxLength: 255
     ZaakType:
       required:
-      - identificatie
       - omschrijving
       - vertrouwelijkheidaanduiding
       - doel
@@ -8812,9 +8812,8 @@ components:
           title: Identificatie
           description: Unieke identificatie van het ZAAKTYPE binnen de CATALOGUS waarin
             het ZAAKTYPE voorkomt.
-          type: integer
-          maximum: 99999
-          minimum: 0
+          type: string
+          maxLength: 50
         omschrijving:
           title: Omschrijving
           description: Omschrijving van de aard van ZAAKen van het ZAAKTYPE.


### PR DESCRIPTION
Legenda:

:boom: breaking change
:sparkles: new feature

---

**BRC**

- :boom: - bij het aanmaken/bijwerken van een besluit moet het `Besluit.besluittype` gepubliceerd zijn

**ZTC**

- :boom: - `Besluittype.zaaktypes` is hernoemd naar `Besluittype.zaaktypen`. Dit manifesteert zich in:
    * response body
    * request body
    * filter parameter
- :boom: - de namen van de scopes zijn aangepast, ze worden namelijk voor alle resources in de catalogi API gebruikt:
    * `zaaktypes.lezen` -> `catalogi.lezen`
    * `zaaktypes.schrijven` -> `catalogi.schrijven`

- :sparkles: - scope `catalogi.geforceerd-verwijderen` toegevoegd (bedoeld voor administrators/API test platform test suite)
- :sparkles: - maximale lengte van `Roltype.omschrijving` verhoogd van 20 naar 100 karakters
- :boom: - `Zaaktype.identificatie` is niet meer beperkt tot integers, maar is nu een string van alfanumerieke karakters (max lengte 50)