### PR TITLE
Changes to publish documentation on Github pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,6 +27,6 @@ plugins:
   - jekyll-redirect-from
   - jekyll-remote-theme
 
-remote_theme: maykinmedia/jekyll-theme-vng
+remote_theme: VNG-realisatie/jekyll-theme-vng
 
 github: VNG-Realisatie/gemma-zaken

--- a/docs/_content/architectuur/ontwerpkeuzes.md
+++ b/docs/_content/architectuur/ontwerpkeuzes.md
@@ -3,5 +3,4 @@ title: "Ontwerpkeuzes"
 date: '27-05-2019'
 ---
 
-<!-- [Ontwerpkeuzes](../overige/technisch/design-keuzes) --> 
-[Ontwerpkeuzes](../themas/achtergronddocumentatie/ontwerpkeuzes.md)
+[Ontwerpkeuzes](../overige/technisch/design-keuzes)

--- a/docs/_content/architectuur/ontwikkelstraat.md
+++ b/docs/_content/architectuur/ontwikkelstraat.md
@@ -3,6 +3,5 @@ title: "Ontwikkelstraat"
 date: '27-05-2019'
 ---
 
-<!-- [Ontwikkelstraat](../overige/technisch/dev-straat)  -->
-[Ontwikkelstraat](../themas/achtergronddocumentatie/ontwikkelstraat.md)
+[Ontwikkelstraat](../overige/technisch/dev-straat) 
 

--- a/docs/_content/architectuur/zds_zgw.md
+++ b/docs/_content/architectuur/zds_zgw.md
@@ -3,5 +3,4 @@ title: "ZDS versus ZGW"
 date: '20-05-2019'
 ---
 
-<!-- [ZDS versus ZGW](../overige/technisch/zds-vs-zgw) -->
-[Zaak- Documentservices vergeleken met de API's voor Zaakgericht werken](../themas/achtergronddocumentatie/zds-en-zgw-apis.md)
+[Zaak- Documentservices vergeleken met de API's voor Zaakgericht werken](../overige/technisch/zds-vs-zgw)

--- a/docs/_content/community/scrumteam.md
+++ b/docs/_content/community/scrumteam.md
@@ -5,15 +5,12 @@ date: '14-6-2019'
 
 Organisatie | Persoon | Rol 
 --- | --- | ---
-VNG / Dimpact | Hugo ter Doest | Product Owner
-VNG | Peter de Graaf | Scrum Master
-VNG | Wishal Gokoel | Project manager/Contactpersoon
-VNG / Maykin Media | Sergei Maertens | Ontwikkelaar
+VNG / Dimpact | Hugo ter Doest | Product Owner Doorontwikkeling
+VNG | Michiel Verhoef | Product Owner Beheer
 VNG / Maykin Media | Joeri Bekker | Ontwikkelaar
 VNG | Henri Korver | Architect/Product Owner API-testvoorziening
 VNG | Ivo Hendriks | Architect
-VNG | Michiel Verhoef | Beheer
-VNG | Robert Melskens | Beheer
+VNG | Wishal Gokoel | Implementatiebevordering
 Gemeente Delft | Edwin Koster | Informatie-Architect a.i
 Gemeente Utrecht | Constantijn Masselink | Stakeholder
 Gemeente Haarlem | Bas de Boer | Stakeholder

--- a/docs/_content/doorontwikkeling/index.md
+++ b/docs/_content/doorontwikkeling/index.md
@@ -10,7 +10,7 @@ Het team dat aan de API's voor Zaakgericht Werken werkt doet dit volgens de agil
 Iedere sprint duurt vier weken. Gemeenten en leveranciers leveren user stories rond zaakgericht 
 werken die vervolgens worden vertaald naar wat nodig is in de API's.
 
-Elke maandag komt het team bijeen op de *dev.vloer* in Utrecht. Er wordt dan samengewerkt op locatie en dan vindt de weekly standup plaats. Overigens wordt op afstand samengewerkt met Github, Slack, etc. als tools. Elke vier weken vindt op maandag de sprint review, sprint retrospective en sprint planning plaats. De sprint review is openbaar en wordt bovendien live gestreamd als webinar. Daarnaast kunnen leveranciers en gemeenten op maandag langskomen op de dev.vloer met vragen.
+Om de vier weken komt het team bijeen op de *dev.vloer* in Utrecht. Er wordt dan samengewerkt op locatie en dan vindt de weekly standup plaats. Overigens wordt op afstand samengewerkt met Github, Slack, etc. als tools. Elke vier weken vindt op maandag de sprint review, sprint retrospective en sprint planning plaats. De sprint review is openbaar en wordt bovendien live gestreamd als webinar. Daarnaast kunnen leveranciers en gemeenten op maandag langskomen op de dev.vloer met vragen.
 
 
 ## Bijdragen

--- a/docs/_content/introductie/index.md
+++ b/docs/_content/introductie/index.md
@@ -4,4 +4,4 @@ layout: subjects
 ---
 
 Zaakgericht werken met de ZGW API's. Er zijn veel ontwikkelingen gaande die 
-allemaal invloed hebben op de opvolger van ZDS 1.2.
+allemaal invloed hebben op de opvolger van Zaak- Documentservices 1.2.

--- a/docs/_content/ontwikkelaars/index.md
+++ b/docs/_content/ontwikkelaars/index.md
@@ -9,28 +9,18 @@ werken, zijn naast de bovengenoemde stanadaardspecificaties, voor de verschillen
 ## Handleidingen
 
 ### Algemene handleidingen
-<!-- De handleidingen vormen een algemene introductie voor ontwikkelaars die met de ZGW API's aan de slag willen.
+De handleidingen vormen een algemene introductie voor ontwikkelaars die met de ZGW API's aan de slag willen.
 1. [Snel aan de slag met de gehoste referentie-implementatie](./handleidingen-en-tutorials/api-guides)
 2. [Installatie en configuratie van een (lokale) kopie van de referentie-implementatie](./handleidingen-en-tutorials/installatie-en-configuratie)
 3. [Gebruik van de demo-applicatie](./handleidingen-en-tutorials/demo-applicatie)
 4. [Gebruik van testscenario's](./handleidingen-en-tutorials/test-scenarios)
 5. [Large files upload (Engels)](./handleidingen-en-tutorials/large-files)
--->
-De handleidingen vormen een algemene introductie voor ontwikkelaars die met de ZGW API's aan de slag willen.
-1. [Snel aan de slag met de gehoste referentie-implementatie](./handleidingen-en-tutorials/api-guides.md)
-2. [Installatie en configuratie van een (lokale) kopie van de referentie-implementatie](./handleidingen-en-tutorials/installatie-en-configuratie.md)
-3. [Gebruik van de demo-applicatie](./handleidingen-en-tutorials/demo-applicatie.md)
-4. [Gebruik van testscenario's](./handleidingen-en-tutorials/test-scenarios.md)
-5. [Large files upload (Engels)](./handleidingen-en-tutorials/large-files.md)
 
 ### Tutorials
 Tutorials zijn introducties gericht op specifieke functionaliteiten binnen de ZGW API's. Deze tutorials Ze zijn ontwikkeld voor gebruik tijdens API lab-bijeenkomsten, maar kunnen ook individueel doorlopen worden.
-<!-- 1. [Eenmalige setup van de referentie-implementaties](./handleidingen-en-tutorials/eenmalige-setup)
+1. [Eenmalige setup van de referentie-implementaties](./handleidingen-en-tutorials/eenmalige-setup)
 2. [Aan de slag met notificeren](./handleidingen-en-tutorials/notificeren)
-3. [Aan de slag met archiveren](./handleidingen-en-tutorials/archiveren)  -->
-1. [Eenmalige setup van de referentie-implementaties](./handleidingen-en-tutorials/eenmalige-setup.md)
-2. [Aan de slag met notificeren](./handleidingen-en-tutorials/notificeren.md)
-3. [Aan de slag met archiveren](./handleidingen-en-tutorials/archiveren.md)
+3. [Aan de slag met archiveren](./handleidingen-en-tutorials/archiveren) 
 
 ## Testomgevingen
 

--- a/docs/_content/overige/functioneel/index.md
+++ b/docs/_content/overige/functioneel/index.md
@@ -3,7 +3,3 @@ title: "Functioneel"
 layout: subjects
 ---
 
-* [Besluiten](besluiten_api.md)
-* [Informatieobjecten](informatieobjecten_api.md)
-* [zaaktypen](zaaktypen_api.md)
-* [zaken](zaken_api.md)

--- a/docs/_content/productvisie/index.md
+++ b/docs/_content/productvisie/index.md
@@ -52,7 +52,7 @@ beschikbaar. Hierin wordt uitvoerig beschreven hoe Zaakgericht Werken bedoeld
 is. Dit is verder uitgewerkt in de GEMMA Informatiearchitectuur in o.a.
 [referentiecomponenten en Integratiepatronen Zaakgericht werken](https://www.gemmaonline.nl/index.php/ZGW_in_GEMMA_2).
 
-Vanaf mei 2018 wordt met een aantal partijen [samengewerkt](../overige/samenwerking.md)
+Vanaf mei 2018 wordt met een aantal partijen [samengewerkt](../overige/samenwerking)
 
 aan realisatie van de ZGW API's.
 
@@ -201,7 +201,7 @@ open [Scrum bord](https://github.com/VNG-Realisatie/gemma-zaken/projects/1).
 Bij de ontwikkeling van de API's wordt gestreefd naar backwards compatibility.
 
 Voor meer informatie over de samenwerking, zie
-[samenwerking](../../../docs/_content/overige/samenwerking.md)
+[samenwerking](../overige/samenwerking)
 
 Naast de (nieuw te ontwikkelen) OpenAPI 3 specificatie wordt een [referentie implementatie](https://nl.wikipedia.org/wiki/Referentie-implementatie) gemaakt.
 De referentie implementatie heeft de volgende karakteristieken:

--- a/docs/_content/standaard/autorisaties/index.md
+++ b/docs/_content/standaard/autorisaties/index.md
@@ -34,8 +34,7 @@ De API ondersteunt de volgende operaties:
 ## Specificatie van gedrag
 
 
-<!-- Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/ac/openapi.yaml)  -->
-Alle operaties beschreven in [`openapi.yaml`](../../../../api-specificatie/ac/openapi.yaml)
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/ac/openapi.yaml) 
 MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de
 referentie-implementatie van het AC.
 

--- a/docs/_content/standaard/besluiten/index.md
+++ b/docs/_content/standaard/besluiten/index.md
@@ -55,8 +55,7 @@ Besluitregistratiecomponenten (BRC) MOETEN aan twee aspecten voldoen:
 
 ### OpenAPI specificatie
 
-<!-- Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/brc/1.0.x/openapi.yaml)  -->
-Alle operaties beschreven in [`openapi.yaml`](../../../../api-specificatie/brc/1.0.x/openapi.yaml)
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/brc/1.0.x/openapi.yaml) 
 MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de
 referentie-implementatie van het BRC.
 

--- a/docs/_content/standaard/catalogi/index.md
+++ b/docs/_content/standaard/catalogi/index.md
@@ -43,8 +43,7 @@ selectielijst-API (waar deze nu nog 1 API is)
 
 ## OpenAPI specificatie
 
-<!-- Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/ztc/1.0.x/openapi.yaml) -->
-Alle operaties beschreven in [`openapi.yaml`](../../../../api-specificatie/ztc/1.0.x/openapi.yaml)
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/ztc/1.0.x/openapi.yaml) 
 MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de
 referentie-implementatie van het ZTC.
 
@@ -151,6 +150,7 @@ Bovendien gelden er beperkingen op verdere acties die uitgevoerd kunnen worden o
 als het `InformatieObjectType` `concept=False` hebben
 
 #### Publiceren van `ZaakType` **<a name="ztc-012">([ztc-012](#ztc-012))</a>**
+
 Een `ZaakType` mag alleen gepubliceerd worden als alle gerelateerde `BesluitType`n en `InformatieObjectType`n `concept=false`
 hebben (dus gepubliceerd zijn). Als er geprobeerd wordt om een `ZaakType` te publiceren terwijl er relaties zijn met `BesluitType`n of `InformatieObjectType`n die `concept=true` hebben, dan dient er een HTTP 400 teruggegeven te worden door de API
 

--- a/docs/_content/standaard/documenten/index.md
+++ b/docs/_content/standaard/documenten/index.md
@@ -68,8 +68,7 @@ documentregistratiecomponentsen (DRC) MOETEN aan twee aspecten voldoen:
 
 ### OpenAPI specificatie
 
-<!-- Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/drc/1.0.x/openapi.yaml)  -->
-Alle operaties beschreven in [`openapi.yaml`](../../../../api-specificatie/drc/1.0.x/openapi.yaml)
+Alle operaties beschreven in [`openapi.yaml`](../../../api-specificatie/drc/1.0.x/openapi.yaml) 
 MOETEN ondersteund worden en tot hetzelfde resultaat leiden als de referentie-
 implementatie van het DRC.
 

--- a/docs/_content/standaard/index.md
+++ b/docs/_content/standaard/index.md
@@ -8,15 +8,6 @@ weight: 10
 
 Hieronder de directe links naar de specificatie en documentatie van de API's:
 
-* [Catalogi API specificatie](../standaard/catalogi/index.md)
-* [Zaken API specificatie](../standaard/zaken/index.md)
-* [Documenten API specificatie](../standaard/documenten/index.md)
-* [Besluiten API specificatie](../standaard/besluiten/index.md)
-* [Autorisaties API specificatie](../standaard/autorisaties/index.md)
-* [Notificaties API specificatie](../standaard/notificaties/index.md)
-* [Notificaties API specificatie voor consumers](../standaard/notificaties-consumer/index.md)
-* [Klantinteracties API specificatie](../standaard/klantinteracties/index.md)
-<!--
 * [Catalogi API specificatie](catalogi/index)
 * [Zaken API specificatie](zaken/index)
 * [Documenten API specificatie](documenten/index)
@@ -25,7 +16,6 @@ Hieronder de directe links naar de specificatie en documentatie van de API's:
 * [Notificaties API specificatie](notificaties/index)
 * [Notificaties API specificatie voor consumers](notificaties-consumer/index)
 * [Klantinteracties API specificatie](klantinteracties/index)
--->
 
 
 ## Algemeen
@@ -43,8 +33,7 @@ Naast deze API zijn er nog een aantal API’s ontwikkeld ter ondersteuning, t.w.
 
 ![overzicht API's](apis.png){:width="700px"}
 
-Voor meer informatie over de visie en achtergronden bij deze API's verwijzen we naar de [productvisie](../productvisie/index.md).
-<!-- Voor meer informatie over de visie en achtergronden bij deze API's verwijzen we naar de [productvisie](../productvisie/index). -->
+Voor meer informatie over de visie en achtergronden bij deze API's verwijzen we naar de [productvisie](../productvisie/index).
 
 
 ## Afhankelijkheden
@@ -76,11 +65,7 @@ De API’s zijn geïnspireerd op RGBZ en imZTC waarin objecten, gegevens en de o
 Het gegevensmodel voor de ZGW API’s benadert het totaalbeeld wat in RGBZ en imZTC wordt geschetst nog het meest. Daar waar in RGBZ resources uit verschillende bronnen en modellen samenkomen is dat in de API’s voor Zaakgericht Werken opgesplitst. Er is een Catalogus API voor de ZTC en Zaken API voor zaken een documenten API voor Document (Informatieobjecten) en een Besluiten API voor Besluiten.
 
 Het diagram toont geen ObjectTypen uit de Autorisatie API en de Notificaties API omdat deze geen (modelleerbare) relaties hebben met ObjectTypen uit de ander API's.
-<!--
 [![Overkoepelend gegevensmodel](./ZGW API's.png){:width="1200px"}](./ZGW API's.png "Gegevensmodel, klik voor grote versie")
--->
-![Overkoepelend gegevensmodel](ZGW API's.png){:width="1200px"}
-<!--(ZGW API's.png "Gegevensmodel, klik voor grote versie") -->
 
 ## Eisen en uitgangspunten die voor alle API's gelden
 
@@ -153,7 +138,7 @@ pagina weer. Dit MOET dezelfde URL zijn als het opvragen van de eerste pagina,
 gevolgd door een query-parameter `page` die het paginanummer bevat, of `null`
 indien er geen volgende of vorige pagina is.
 
-De eerste pagina MOET `1` zijn (en niet `0`). De URL's
+De eerste pagina MOET `1` zijn (en niet `0`). De URLs
 `http://example.com/api/v1/resource` en
 `http://example.com/api/v1/resource?page=1` MOETEN hetzelfde resultaat geven.
 
@@ -188,8 +173,7 @@ Als een wijziging van de API root URL **wel** invloed heeft op de inhoud van de
 API, ofwel, het betreft een versiewijziging, dan MAG de API op de oude
 `{API root URL}` GEEN HTTP 301 teruggeven naar de nieuwe `{API root URL}`.
 
-<!-- Zie: achtergrond bij [versies en migraties](/themas/achtergronddocumentatie/versies-en-migraties) -->
-Zie: achtergrond bij [versies en migraties](../themas/achtergronddocumentatie/versies-en-migraties.md)
+Zie: achtergrond bij [versies en migraties](/themas/achtergronddocumentatie/versies-en-migraties) 
 
 ### Beschikbaar stellen van de OAS
 
@@ -220,17 +204,10 @@ Een duur MOET in [ISO-8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Dur
 uitgedrukt worden.
 
 ### API-compatibiliteit
-De API-specificaties hebben ieder hun eigen versie en doorontwikkeling. Echter, ze hebben ook afhankelijkheden, waardoor niet alle versies van de API's met elkaar kunnen samenwerken. [Hier](api-compatibiliteit.md) vind je een overzicht van de API-versies die compatibel zijn met elkaar.
-<!--
-### API-compatibiliteit
+
 De API-specificaties hebben ieder hun eigen versie en doorontwikkeling. Echter, ze hebben ook afhankelijkheden, waardoor niet alle versies van de API's met elkaar kunnen samenwerken. [Hier](./api-compatibiliteit) vind je een overzicht van de API-versies die compatibel zijn met elkaar.
--->
 
 ## Overige documentatie
 
-* [Achtergronddocumentatie](../themas/index.md)
-* [Documentatie voor ontwikkelaars (handleidingen en tutorials)](../ontwikkelaars/index.md)
-<!--
 * [Achtergronddocumentatie](../themas/index)
 * [Documentatie voor ontwikkelaars (handleidingen en tutorials)](/ontwikkelaars/index)
--->

--- a/docs/_content/standaard/notificaties/index.md
+++ b/docs/_content/standaard/notificaties/index.md
@@ -35,13 +35,11 @@ De API ondersteunt:
 
 Componenten dienen events te publiceren naar (een)
 notificatierouteringcomponent(en) (NRC). De NRC MOET volledig de
-[`openapi.yaml`](../../../../api-specificatie/nrc/openapi.yaml) implementeren.
-<!-- [`openapi.yaml`](../../../api-specificatie/nrc/openapi.yaml) implementeren. -->
+[`openapi.yaml`](../../../api-specificatie/nrc/openapi.yaml) implementeren. 
 
 Applicaties MOGEN een abonnement nemen op 1 of meer kanalen. Deze applicaties
 zijn dan event consumers. Een event consumer MOET de
-<!-- [API volgens `openapi.yaml`](../../../api-specificatie/nrc/consumer-api/openapi.yaml) -->
-[API volgens `openapi.yaml`](../../../../api-specificatie/nrc/consumer-api/openapi.yaml)
+[API volgens `openapi.yaml`](../../../api-specificatie/nrc/consumer-api/openapi.yaml) 
 implementeren om berichten te kunnen ontvangen.
 
 Componenten geven aan indien het nemen van een abonnement op bepaalde kanalen
@@ -132,5 +130,4 @@ We eisen deze maatregelen dus niet in de specificatie.
 
 ## Overige documentatie
 
-* [Tutorial Notificeren](../../ontwikkelaars/handleidingen-en-tutorials/notificeren.md)
-<!-- * [Tutorial Notificeren](../../ontwikkelaars/handleidingen-en-tutorials/notificeren) -->
+* [Tutorial Notificeren](../../ontwikkelaars/handleidingen-en-tutorials/notificeren)

--- a/docs/_content/standaard/zaken/index.md
+++ b/docs/_content/standaard/zaken/index.md
@@ -255,7 +255,7 @@ antwoorden met een `HTTP 400` foutbericht.
 
 Het ophalen van deze resource moet een JSON-document zijn met de vorm van
 een communicatiekanaal zoals gedocumenteerd op de
-[referentielijsten-api](https://ref.tst.vng.cloud/referentielijsten/api/v1/schema/#operation/communicatiekanaal_read):
+[referentielijsten-api](https://referentielijsten-api.vng.cloud/api/v1/schema/#operation/communicatiekanaal_read):
 
 ```json
 {

--- a/docs/_content/themas/achtergronddocumentatie/zds-en-zgw-apis.md
+++ b/docs/_content/themas/achtergronddocumentatie/zds-en-zgw-apis.md
@@ -30,7 +30,7 @@ Zaak- Documentservices kent extraElementen, label-value combinaties voor gegeven
 
 ### Operaties
 
-Alle ZGW APIs zitten nu\* op versie 1.0.0-alpha.
+Alle ZGW APIs zitten nu\* op versie 1.0.0
 
 ZDS 1.2 | ZGW APIs\*
 --- | ---


### PR DESCRIPTION
Ik heb de links weer terug gerepareerd zodat eea. weer werkt via github pages. 

TODO: het gekloonde theme (jekyll-theme-vng) aanpassen naar een minder VNG uiterlijk. Maar dit moet in https://github.com/VNG-Realisatie/jekyll-theme-vng 
