### PR TITLE
Klantinteractie API uitgebreid met voorkeurskanaal

### DIFF
--- a/api-specificatie/DESIGN/kic/openapi.yaml
+++ b/api-specificatie/DESIGN/kic/openapi.yaml
@@ -4462,6 +4462,11 @@ components:
             wordt
           type: string
           maxLength: 50
+        voorkeurskanaal:
+          title: Voorkeurskanaal
+          description: Het communicatiekanaal dat voor opvolging van het CONTACTMOMENT de voorkeur heeft van de KLANT
+          type: string
+          maxLength: 50
         tekst:
           title: Tekst
           description: Een toelichting die inhoudelijk het contact met de klant beschrijft.
@@ -4954,6 +4959,11 @@ components:
           description: De datum en het tijdstip waarop het CONTACTMOMENT begint
           type: string
           format: date-time
+        voorkeurskanaal:
+          title: Voorkeurskanaal
+          description: Het communicatiekanaal dat voor opvolging van het VERZOEK de voorkeur heeft van de KLANT
+          type: string
+          maxLength: 50
         tekst:
           title: Tekst
           description: Een toelichting die inhoudelijk het contact met de klant beschrijft.


### PR DESCRIPTION
Zowel bij Contactmoment als bij Verzoek het veld "voorkeurskanaal" toegevoegd (zie #1310).