### PR TITLE
Infrastructure fixes after latest merges in reference implementations

### DIFF
--- a/infra/ansible/vars/stable.yml
+++ b/infra/ansible/vars/stable.yml
@@ -31,39 +31,48 @@ services:
 
   - name: ac
     templates: ../k8s/ac/
+    domain: autorisaties-api.vng.cloud
     image_tag: '1.0.0'
 
   - name: brc
     templates: ../k8s/brc/
+    domain: besluiten-api.vng.cloud
     image_tag: '1.0.1.post0'
 
   - name: drc
     templates: ../k8s/drc/
+    domain: documenten-api.vng.cloud
     image_tag: '1.0.1.post0'
     min_upload_size: 4294967296  # 4GB
 
   - name: nrc
     templates: ../k8s/nrc/
+    domain: notificaties-api.vng.cloud
     image_tag: '1.0.0.post1'
 
   - name: zrc
     templates: ../k8s/zrc/
+    domain: zaken-api.vng.cloud
     image_tag: '1.0.1.post0'
 
   - name: ztc
     templates: ../k8s/ztc/
+    domain: catalogi-api.vng.cloud
     image_tag: '1.0.0.post4'
 
   - name: klanten
     templates: ../k8s/klanten/
+    domain: klanten-api.vng.cloud
     image_tag: 'latest'
 
   - name: contactmomenten
     templates: ../k8s/contactmomenten/
+    domain: contactmomenten-api.vng.cloud
     image_tag: 'latest'
 
   - name: verzoeken
     templates: ../k8s/verzoeken/
+    domain: verzoeken-api.vng.cloud
     image_tag: 'latest'
 
   # Unofficial APIs

--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -29,39 +29,48 @@ services:
 
   - name: ac-test
     templates: ../k8s/ac/
+    domain: autorisaties-api.test.vng.cloud
     image_tag: latest
 
   - name: brc-test
     templates: ../k8s/brc/
+    domain: besluiten-api.test.vng.cloud
     image_tag: latest
 
   - name: drc-test
     templates: ../k8s/drc/
+    domain: documenten-api.test.vng.cloud
     image_tag: latest
     min_upload_size: 4294967296  # 4GB
 
   - name: nrc-test
     templates: ../k8s/nrc/
+    domain: notificaties-api.test.vng.cloud
     image_tag: latest
 
   - name: zrc-test
     templates: ../k8s/zrc/
+    domain: zaken-api.test.vng.cloud
     image_tag: latest
 
   - name: ztc-test
     templates: ../k8s/ztc/
+    domain: catalogi-api.test.vng.cloud
     image_tag: develop
 
   - name: klanten-test
     templates: ../k8s/klanten/
+    domain: klanten-api.test.vng.cloud
     image_tag: 'latest'
 
   - name: contactmomenten-test
     templates: ../k8s/contactmomenten/
+    domain: contactmomenten-api.test.vng.cloud
     image_tag: 'latest'
 
   - name: verzoeken-test
     templates: ../k8s/verzoeken/
+    domain: verzoeken-api.test.vng.cloud
     image_tag: 'latest'
 
   # Unofficial APIs

--- a/infra/k8s/ac/web.yml
+++ b/infra/k8s/ac/web.yml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: {{ service.name }}
-        image: vngr/gemma-autorisatiecomponent:{{ service.image_tag }}
+        image: vngr/autorisaties-api:{{ service.image_tag }}
         imagePullPolicy: Always
         resources:
           requests:

--- a/infra/k8s/ac/web.yml
+++ b/infra/k8s/ac/web.yml
@@ -52,6 +52,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: ac.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/brc/web.yml
+++ b/infra/k8s/brc/web.yml
@@ -52,6 +52,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: brc.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/contactmomenten/web.yml
+++ b/infra/k8s/contactmomenten/web.yml
@@ -52,6 +52,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: contactmomenten.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/drc/web.yml
+++ b/infra/k8s/drc/web.yml
@@ -11,6 +11,8 @@ metadata:
     k8s-app: {{ service.name }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate  # required to be able to (re) mount the RWO PV
   selector:
     matchLabels:
       k8s-app: {{ service.name }}

--- a/infra/k8s/drc/web.yml
+++ b/infra/k8s/drc/web.yml
@@ -60,6 +60,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: drc.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/klanten/web.yml
+++ b/infra/k8s/klanten/web.yml
@@ -52,6 +52,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: klanten.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/nrc/celery.yml
+++ b/infra/k8s/nrc/celery.yml
@@ -27,6 +27,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: nrc.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/nrc/web.yml
+++ b/infra/k8s/nrc/web.yml
@@ -52,6 +52,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: nrc.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/verzoeken/web.yml
+++ b/infra/k8s/verzoeken/web.yml
@@ -52,6 +52,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: verzoeken.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/zrc/web.yml
+++ b/infra/k8s/zrc/web.yml
@@ -53,6 +53,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: zrc.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME

--- a/infra/k8s/ztc/web.yml
+++ b/infra/k8s/ztc/web.yml
@@ -53,6 +53,8 @@ spec:
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: ztc.conf.docker
+          - name: ALLOWED_HOSTS
+            value: "{{ service.domain }},localhost"
           - name: DB_HOST
             value: {{ db_host }}
           - name: DB_NAME


### PR DESCRIPTION
The main culprit was the failing liveness/readiness probes because of the invalid host - the latest changes default to an empty `ALLOWED_HOSTS` list.

This envvar is now included in the k8s deployments.