### PR TITLE
Tekst over toekomstige ontwikkelingen weggehaald

### DIFF
--- a/docs/_content/standaard/notificaties/index.md
+++ b/docs/_content/standaard/notificaties/index.md
@@ -74,13 +74,6 @@ In de documentatie van elke bron MOET beschreven zijn welke kanalen en
 kenmerken geldig zijn. Tevens MOET beschreven zijn welke gebeurtenissen tot
 een notificatie leiden.
 
-### Toekomstige ontwikkelingen
-
-* pollen
-* berichten bewaren (retentie)
-* (gemiste) berichten opvragen
-* abonnementen automatisch annuleren indien herhaaldelijk fout bij afleveren
-
 
 ### Audittrail
 


### PR DESCRIPTION
Tekst over de toekomstige ontwikkelingen weggehaald. De genoemde  onderwerpen zullen niet worden toegevoegd aan de standaard tenzij er user stories worden ingediend waaruit blijkt dat er een grote noodzaak is.
