### PR TITLE
:rocket: Remove nlx inway from stable deployment

### DIFF
--- a/infra/ansible/vars/stable.yml
+++ b/infra/ansible/vars/stable.yml
@@ -101,8 +101,8 @@ services:
   - name: deploy
     templates: ../k8s/deploy/
 
-  - name: inway
-    templates: ../k8s/inway/
+  # - name: inway
+  #   templates: ../k8s/inway/
 
 ingress:
   name: ref-implementatie


### PR DESCRIPTION
since it's not being used and the deployment is outdated (inway has to be deployed using a management API: https://hub.docker.com/r/nlxio/management-api)