### PR TITLE
Update DRC test environment to 1.2.0-rc1

### DIFF
--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -40,7 +40,7 @@ services:
   - name: drc-test
     templates: ../k8s/drc/
     domain: documenten-api.test.vng.cloud
-    image_tag: latest
+    image_tag: '1.2.0-rc1'
     min_upload_size: 4294967296  # 4GB
 
   - name: nrc-test


### PR DESCRIPTION
Deze aanpassing zorgt ervoor dat de test omgeving van het DRC geupdate wordt naar de `1.2.0-rc1` tag.