### PR TITLE
Update ZTC & ZRC test environments

### DIFF
--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -51,13 +51,13 @@ services:
   - name: zrc-test
     templates: ../k8s/zrc/
     domain: zaken-api.test.vng.cloud
-    image_tag: '1.3.0-alpha1'
-  
+    image_tag: '1.3.0-alpha5'
+
   - name: ztc-test
     templates: ../k8s/ztc/
     domain: catalogi-api.test.vng.cloud
-    image_tag: "1846"
-  
+    image_tag: '1.2.0-alpha2'
+
   - name: klanten-test
     templates: ../k8s/klanten/
     domain: klanten-api.test.vng.cloud


### PR DESCRIPTION
ZTC maakt nu ook gebruik van de versienummering die de andere ZGW componenten gebruiken en ZRC z'n versienummer staat nu goed.