### PR TITLE
feat: bumps version for deployment

### DIFF
--- a/infra/ansible/auth_workaround.sh
+++ b/infra/ansible/auth_workaround.sh
@@ -4,6 +4,7 @@
 # EXAMPLE USAGE:
 # $ source ./auth_workaround.sh
 # $ ansible-playbook deploy-stable.yml --ask-vault-pass
+# $ ansible-playbook deploy-test.yml --ask-vault-password
 
 mkdir -p ~/.tmp
 

--- a/infra/ansible/hosts
+++ b/infra/ansible/hosts
@@ -1,2 +1,2 @@
 [local]
-localhost ansible_connection=local ansible_python_interpreter=../env/bin/python
+localhost ansible_connection=local ansible_python_interpreter=../venv/bin/python

--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -40,7 +40,7 @@ services:
   - name: drc-test
     templates: ../k8s/drc/
     domain: documenten-api.test.vng.cloud
-    image_tag: '1.2.0-rc1'
+    image_tag: '1.2.0-rc2'
     min_upload_size: 4294967296  # 4GB
 
   - name: nrc-test
@@ -51,23 +51,23 @@ services:
   - name: zrc-test
     templates: ../k8s/zrc/
     domain: zaken-api.test.vng.cloud
-    image_tag: '1.3.0-rc1'
+    image_tag: '1.3.0-rc2'
 
   - name: ztc-test
     templates: ../k8s/ztc/
     domain: catalogi-api.test.vng.cloud
-    image_tag: '1.2.0-rc1'
+    image_tag: '1.2.0-rc2'
 
   - name: klanten-test
     templates: ../k8s/klanten/
     domain: klanten-api.test.vng.cloud
     image_tag: 'latest'
-  
+
   - name: contactmomenten-test
     templates: ../k8s/contactmomenten/
     domain: contactmomenten-api.test.vng.cloud
     image_tag: 'latest'
-  
+
   - name: verzoeken-test
     templates: ../k8s/verzoeken/
     domain: verzoeken-api.test.vng.cloud
@@ -85,7 +85,7 @@ services:
 
   - name: docs-test
     templates: ../k8s/docs
-  
+
   - name: token-issuer-test
     templates: ../k8s/tokens
     image_tag: latest

--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -36,7 +36,7 @@ jinja2==2.11.3
     #   openshift
 jsonschema==3.2.0
     # via kubernetes-validate
-kubernetes==10.1.0
+kubernetes==12.0.1
     # via openshift
 kubernetes-validate==1.16.0
     # via -r requirements.in
@@ -44,7 +44,7 @@ markupsafe==1.1.1
     # via jinja2
 oauthlib==3.1.0
     # via requests-oauthlib
-openshift==0.10.3
+openshift==0.12.1
     # via -r requirements.in
 packaging==21.3
     # via ansible-core


### PR DESCRIPTION
For deployments we need newer versions of both the openshift and kubernetes modules for python. These have been upgraded in this PR.