### PR TITLE
Update ZTC test environment

### DIFF
--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -56,7 +56,7 @@ services:
   - name: ztc-test
     templates: ../k8s/ztc/
     domain: catalogi-api.test.vng.cloud
-    image_tag: '1.2.0-rc4'
+    image_tag: '1.2.0-rc5'
 
   - name: klanten-test
     templates: ../k8s/klanten/


### PR DESCRIPTION
Tijdens het configureren van de test omgevingen (zodat zij weer werken met de oude notificaties API) liep ik er tegen aan dat `Zaak`'en niet meer benaderbaar waren in de admin:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/options.py", line 616, in wrapper
    return self.admin_site.admin_view(view)(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/sites.py", line 232, in inner
    return view(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/options.py", line 1660, in change_view
    return self.changeform_view(request, object_id, form_url, extra_context)
  File "/usr/local/lib/python3.9/site-packages/django/utils/decorators.py", line 43, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/options.py", line 1540, in changeform_view
    return self._changeform_view(request, object_id, form_url, extra_context)
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/options.py", line 1604, in _changeform_view
    formsets, inline_instances = self._create_formsets(request, obj, change=True)
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/options.py", line 1961, in _create_formsets
    for FormSet, inline in self.get_formsets_with_inlines(*get_formsets_args):
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/options.py", line 798, in get_formsets_with_inlines
    for inline in self.get_inline_instances(request, obj):
  File "/usr/local/lib/python3.9/site-packages/django/contrib/admin/options.py", line 605, in get_inline_instances
    if not inline.has_add_permission(request, obj):
TypeError: has_add_permission() takes 2 positional arguments but 3 were given
```
In deze nieuwe versie is dat verholpen.