### PR TITLE
Documenten catalogi zaken test bump version

### DIFF
--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -51,7 +51,7 @@ services:
   - name: zrc-test
     templates: ../k8s/zrc/
     domain: zaken-api.test.vng.cloud
-    image_tag: '1.3.0-rc5'
+    image_tag: '1.3.0-rc6'
 
   - name: ztc-test
     templates: ../k8s/ztc/

--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -56,7 +56,7 @@ services:
   - name: ztc-test
     templates: ../k8s/ztc/
     domain: catalogi-api.test.vng.cloud
-    image_tag: '1.2.0-rc6'
+    image_tag: '1.2.0-rc8'
 
   - name: klanten-test
     templates: ../k8s/klanten/

--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -40,7 +40,7 @@ services:
   - name: drc-test
     templates: ../k8s/drc/
     domain: documenten-api.test.vng.cloud
-    image_tag: '1.2.0-rc3'
+    image_tag: '1.2.0-rc5'
     min_upload_size: 4294967296  # 4GB
 
   - name: nrc-test

--- a/infra/ansible/vars/test.yml
+++ b/infra/ansible/vars/test.yml
@@ -40,7 +40,7 @@ services:
   - name: drc-test
     templates: ../k8s/drc/
     domain: documenten-api.test.vng.cloud
-    image_tag: '1.2.0-rc5'
+    image_tag: '1.2.0-rc6'
     min_upload_size: 4294967296  # 4GB
 
   - name: nrc-test


### PR DESCRIPTION
documenten is 3 versies gebumped omdat o.a vorige branches nog niet naar master waren gemerged in deze repo.
catalogi is 2 versies gebumped omdat 'generate_schema' eerste keer niet gedaan was.