### PR TITLE
Verscherpen beschrijvingen in OAS om verkeerde  interpretatie te voorkomen

### DIFF
--- a/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
@@ -13066,13 +13066,14 @@ components:
           niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_Rol'
           organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_Rol'
           vestiging: '#/components/schemas/vestiging_Rol'
-    RolExpanded:
-     allOf:
-     - $ref: '#/components/schemas/Rol'
-     - properties:
-          _expand:
-            $ref: '#/components/schemas/RolEmbedded'
+    # RolExpanded:
+    #  allOf:
+    #  - $ref: '#/components/schemas/Rol'
+    #  - properties:
+    #       _expand:
+    #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
+      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14137,7 +14138,7 @@ components:
         rollen: 
           type: array
           items: 
-            $ref: '#/components/schemas/RolExpanded'   
+            $ref: '#/components/schemas/Rol'   
         status:
           oneOf:
           - $ref: '#/components/schemas/StatusExpanded'

--- a/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
@@ -14588,14 +14588,15 @@ components:
           woz_waarde: '#/components/schemas/woz_waarde_ZaakObject'
           zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObject'
           overige: '#/components/schemas/overige_ZaakObject'
-    ZaakObjectExpanded:
-      allOf:
-      - $ref: '#/components/schemas/ZaakObject'
-      - properties:
-            _expand:
-              $ref: '#/components/schemas/ZaakObjectEmbedded'
+    # ZaakObjectExpanded:
+    #   allOf:
+    #   - $ref: '#/components/schemas/ZaakObject'
+    #   - properties:
+    #         _expand:
+    #           $ref: '#/components/schemas/ZaakObjectEmbedded'
     ZaakObjectEmbedded:
       type: object
+      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'
@@ -14926,8 +14927,10 @@ components:
               type: string
               example: "123456789"
             expand:
-              description: "Examples: \n`expand=zaaktype, status, status.statustype, hoofdzaak.status.statustype,' \
-            \ hoofdzaak.deelzaken.status.statustype`Haal details van gelinkte resources direct op. Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt."
+              description: "Examples: \n`expand=zaaktype, status, status.statustype, hoofdzaak.status.statustype,` \
+                   \ hoofdzaak.deelzaken.status.statustype`Haal details van gelinkte resources direct op. 
+                   Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. 
+                   Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt."
               title: expand
               type: string
               example: zaaktype, status, status.statustype, hoofdzaak.status.statustype, hoofdzaak.deelzaken.status.statustype              

--- a/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
@@ -13073,7 +13073,7 @@ components:
     #       _expand:
     #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
-      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14597,7 +14597,7 @@ components:
     #           $ref: '#/components/schemas/ZaakObjectEmbedded'
     ZaakObjectEmbedded:
       type: object
-      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'

--- a/api-specificatie/zrc/current_version/openapi.yaml
+++ b/api-specificatie/zrc/current_version/openapi.yaml
@@ -12418,11 +12418,6 @@ components:
             Omschrijving van het object, subject of gebeurtenis waarop,
             vanuit archiveringsoptiek, de zaak betrekking heeft.
           maxLength: 200
-        resultaattoelichting:
-          type: string
-          description: Een toelichting op wat het resultaat van de zaak inhoudt.
-          title: resultaattoelichting
-          maxLength: 1000
         startdatumBewaartermijn:
           type: string
           format: date
@@ -13071,13 +13066,14 @@ components:
           niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_Rol'
           organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_Rol'
           vestiging: '#/components/schemas/vestiging_Rol'
-    RolExpanded:
-     allOf:
-     - $ref: '#/components/schemas/Rol'
-     - properties:
-          _expand:
-            $ref: '#/components/schemas/RolEmbedded'
+    # RolExpanded:
+    #  allOf:
+    #  - $ref: '#/components/schemas/Rol'
+    #  - properties:
+    #       _expand:
+    #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14074,11 +14070,6 @@ components:
             Omschrijving van het object, subject of gebeurtenis waarop,
             vanuit archiveringsoptiek, de zaak betrekking heeft.
           maxLength: 200
-        resultaattoelichting:
-          type: string
-          description: Een toelichting op wat het resultaat van de zaak inhoudt.
-          title: resultaattoelichting
-          maxLength: 1000
         startdatumBewaartermijn:
           type: string
           format: date
@@ -14147,7 +14138,7 @@ components:
         rollen: 
           type: array
           items: 
-            $ref: '#/components/schemas/RolExpanded'   
+            $ref: '#/components/schemas/Rol'   
         status:
           oneOf:
           - $ref: '#/components/schemas/StatusExpanded'
@@ -14598,14 +14589,15 @@ components:
           woz_waarde: '#/components/schemas/woz_waarde_ZaakObject'
           zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObject'
           overige: '#/components/schemas/overige_ZaakObject'
-    ZaakObjectExpanded:
-      allOf:
-      - $ref: '#/components/schemas/ZaakObject'
-      - properties:
-            _expand:
-              $ref: '#/components/schemas/ZaakObjectEmbedded'
+    # ZaakObjectExpanded:
+    #   allOf:
+    #   - $ref: '#/components/schemas/ZaakObject'
+    #   - properties:
+    #         _expand:
+    #           $ref: '#/components/schemas/ZaakObjectEmbedded'
     ZaakObjectEmbedded:
       type: object
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'
@@ -14935,6 +14927,14 @@ components:
               description: Een korte identificatie van de organisatorische eenheid.
               type: string
               example: "123456789"
+            expand:
+              description: "Examples: \n`expand=zaaktype, status, status.statustype, hoofdzaak.status.statustype,` \
+                   \ hoofdzaak.deelzaken.status.statustype`Haal details van gelinkte resources direct op. 
+                   Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. 
+                   Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt."
+              title: expand
+              type: string
+              example: zaaktype, status, status.statustype, hoofdzaak.status.statustype, hoofdzaak.deelzaken.status.statustype              
             ordering:
               title: Ordering
               description: Het veld waarop de resultaten geordend worden. Het minnetje betekent omgekeerde volgorde.


### PR DESCRIPTION
Naar aanleiding van issues #2412 en #2414 de beschrijvingen in de OAS verbeterd zodat verkeerde interpretatie kan worden voorkomen. Er zijn geen functionele wijzigingen doorgevoerd. Een versieverhoging van de OAS is hopelijk niet nodig.