### PR TITLE
Oplossen fout in OAS m.b.t. expand

### DIFF
--- a/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
@@ -13066,13 +13066,14 @@ components:
           niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_Rol'
           organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_Rol'
           vestiging: '#/components/schemas/vestiging_Rol'
-    RolExpanded:
-     allOf:
-     - $ref: '#/components/schemas/Rol'
-     - properties:
-          _expand:
-            $ref: '#/components/schemas/RolEmbedded'
+    # RolExpanded:
+    #  allOf:
+    #  - $ref: '#/components/schemas/Rol'
+    #  - properties:
+    #       _expand:
+    #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
+      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14137,7 +14138,7 @@ components:
         rollen: 
           type: array
           items: 
-            $ref: '#/components/schemas/RolExpanded'   
+            $ref: '#/components/schemas/Rol'   
         status:
           oneOf:
           - $ref: '#/components/schemas/StatusExpanded'

--- a/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
@@ -14588,14 +14588,15 @@ components:
           woz_waarde: '#/components/schemas/woz_waarde_ZaakObject'
           zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObject'
           overige: '#/components/schemas/overige_ZaakObject'
-    ZaakObjectExpanded:
-      allOf:
-      - $ref: '#/components/schemas/ZaakObject'
-      - properties:
-            _expand:
-              $ref: '#/components/schemas/ZaakObjectEmbedded'
+    # ZaakObjectExpanded:
+    #   allOf:
+    #   - $ref: '#/components/schemas/ZaakObject'
+    #   - properties:
+    #         _expand:
+    #           $ref: '#/components/schemas/ZaakObjectEmbedded'
     ZaakObjectEmbedded:
       type: object
+      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'
@@ -14926,8 +14927,10 @@ components:
               type: string
               example: "123456789"
             expand:
-              description: "Examples: \n`expand=zaaktype, status, status.statustype, hoofdzaak.status.statustype,' \
-            \ hoofdzaak.deelzaken.status.statustype`Haal details van gelinkte resources direct op. Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt."
+              description: "Examples: \n`expand=zaaktype, status, status.statustype, hoofdzaak.status.statustype,` \
+                   \ hoofdzaak.deelzaken.status.statustype`Haal details van gelinkte resources direct op. 
+                   Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. 
+                   Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt."
               title: expand
               type: string
               example: zaaktype, status, status.statustype, hoofdzaak.status.statustype, hoofdzaak.deelzaken.status.statustype              

--- a/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
@@ -13045,8 +13045,6 @@ components:
             dat STATUSsen in die ZAAK bereikt zijn.
           title: statussen
           uniqueItems: true
-        _expand:
-            $ref: '#/components/schemas/RolEmbedded'
       required:
         - betrokkeneType
         - omschrijving
@@ -13066,6 +13064,168 @@ components:
           niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_Rol'
           organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_Rol'
           vestiging: '#/components/schemas/vestiging_Rol'
+    RolExpanded:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        betrokkene:
+          type: string
+          format: uri
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          title: betrokkene
+          maxLength: 1000
+        betrokkeneType:
+          allOf:
+            - $ref: '#/components/schemas/BetrokkeneTypeEnum'
+          description: 'Type van de `betrokkene`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `vestiging` - Vestiging
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `medewerker` - Medewerker'
+          title: betrokkene type
+        afwijkendeNaamBetrokkene:
+          type: string
+          description:
+            De naam van de betrokkene waaronder deze in relatie tot de
+            zaak aangesproken wil worden.
+          title: afwijkende naam betrokkene
+          maxLength: 625
+        roltype:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar een roltype binnen het ZAAKTYPE van de
+            ZAAK.
+          title: roltype
+          maxLength: 1000
+        omschrijving:
+          type: string
+          readOnly: true
+          description: Omschrijving van de aard van de ROL, afgeleid uit het ROLTYPE.
+          title: omschrijving
+        omschrijvingGeneriek:
+          type: string
+          readOnly: true
+          description:
+            "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid\
+            \ uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` -\
+            \ (Adviseur) Kennis in dienst stellen van de behandeling van (een deel\
+            \ van) een zaak.\n* `behandelaar` - (Behandelaar) De vakinhoudelijke behandeling\
+            \ doen van (een deel van) een zaak.\n* `belanghebbende` - (Belanghebbende)\
+            \ Vanuit eigen en objectief belang rechtstreeks betrokken zijn bij de\
+            \ behandeling en/of de uitkomst van een zaak.\n* `beslisser` - (Beslisser)\
+            \ Nemen van besluiten die voor de uitkomst van een zaak noodzakelijk zijn.\n\
+            * `initiator` - (Initiator) Aanleiding geven tot de start van een zaak\
+            \ ..\n* `klantcontacter` - (Klantcontacter) Het eerste aanspreekpunt zijn\
+            \ voor vragen van burgers en bedrijven ..\n* `zaakcoordinator` - (Zaakco\xF6\
+            rdinator) Er voor zorg dragen dat de behandeling van de zaak in samenhang\
+            \ uitgevoerd wordt conform de daarover gemaakte afspraken.\n* `mede_initiator`\
+            \ - Mede-initiator"
+          title: omschrijving generiek
+        roltoelichting:
+          type: string
+          title: roltoelichting
+          maxLength: 1000
+        registratiedatum:
+          type: string
+          format: date-time
+          readOnly: true
+          description: De datum waarop dit object is geregistreerd.
+          title: registratiedatum
+        indicatieMachtiging:
+          description: 'Indicatie machtiging
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `gemachtigde` - De betrokkene in de rol bij de zaak is door een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen
+
+            * `machtiginggever` - De betrokkene in de rol bij de zaak heeft een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen'
+          title: indicatie machtiging
+          oneOf:
+            - $ref: '#/components/schemas/IndicatieMachtigingEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        contactpersoonRol:
+          allOf:
+            - $ref: '#/components/schemas/ContactPersoonRol'
+          nullable: true
+          description:
+            De gegevens van de persoon die anderen desgevraagd in contact
+            brengt met medewerkers van de BETROKKENE, een NIET-NATUURLIJK PERSOON
+            of VESTIGING zijnde, of met BETROKKENE zelf, een NATUURLIJK PERSOON zijnde
+            , vanuit het belang van BETROKKENE in haar ROL bij een ZAAK.
+          title: contactpersoonRol
+        statussen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+            minLength: 1
+            maxLength: 1000
+          readOnly: true
+          description:
+            De BETROKKENE die in zijn/haar ROL in een ZAAK heeft geregistreerd
+            dat STATUSsen in die ZAAK bereikt zijn.
+          title: statussen
+          uniqueItems: true
+        _expand:
+            $ref: '#/components/schemas/RolEmbedded'
+      required:
+        - betrokkeneType
+        - omschrijving
+        - omschrijvingGeneriek
+        - registratiedatum
+        - roltoelichting
+        - roltype
+        - statussen
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: betrokkeneType
+        mapping:
+          medewerker: '#/components/schemas/medewerker_RolExpanded'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_RolExpanded'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_RolExpanded'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_RolExpanded'
+          vestiging: '#/components/schemas/vestiging_RolExpanded'
+
     # RolExpanded:
     #  allOf:
     #  - $ref: '#/components/schemas/Rol'
@@ -13073,7 +13233,6 @@ components:
     #       _expand:
     #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
-      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14138,7 +14297,7 @@ components:
         rollen: 
           type: array
           items: 
-            $ref: '#/components/schemas/Rol'   
+            $ref: '#/components/schemas/RolExpanded'   
         status:
           oneOf:
           - $ref: '#/components/schemas/StatusExpanded'
@@ -14146,7 +14305,7 @@ components:
         zaakobjecten:
           type: array
           items: 
-           $ref: '#/components/schemas/ZaakObject'
+           $ref: '#/components/schemas/ZaakObjectExpanded'
         resultaat:
           oneOf:
           - $ref: '#/components/schemas/ResultaatExpanded'
@@ -14548,8 +14707,6 @@ components:
           description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
           title: relatieomschrijving
           maxLength: 80
-        _expand:
-            $ref: '#/components/schemas/ZaakObjectEmbedded'
       required:
         - objectType
         - url
@@ -14589,15 +14746,198 @@ components:
           woz_waarde: '#/components/schemas/woz_waarde_ZaakObject'
           zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObject'
           overige: '#/components/schemas/overige_ZaakObject'
-    # ZaakObjectExpanded:
-    #   allOf:
-    #   - $ref: '#/components/schemas/ZaakObject'
-    #   - properties:
-    #         _expand:
-    #           $ref: '#/components/schemas/ZaakObjectEmbedded'
+    ZaakObjectExpanded:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        object:
+          type: string
+          format: uri
+          description: URL-referentie naar de resource die het OBJECT beschrijft.
+          title: object
+          maxLength: 1000
+        zaakobjecttype:
+          type: string
+          format: uri
+          description: URL-referentie naar het ZAAKOBJECTTYPE (in de Catalogi API).
+          title: zaakobjecttype
+          maxLength: 1000
+        objectType:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeEnum'
+          description:
+            'Beschrijft het type OBJECT gerelateerd aan de ZAAK. Als er
+            geen passend type is, dan moet het type worden opgegeven onder `objectTypeOverige`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `adres` - Adres
+
+            * `besluit` - Besluit
+
+            * `buurt` - Buurt
+
+            * `enkelvoudig_document` - Enkelvoudig document
+
+            * `gemeente` - Gemeente
+
+            * `gemeentelijke_openbare_ruimte` - Gemeentelijke openbare ruimte
+
+            * `huishouden` - Huishouden
+
+            * `inrichtingselement` - Inrichtingselement
+
+            * `kadastrale_onroerende_zaak` - Kadastrale onroerende zaak
+
+            * `kunstwerkdeel` - Kunstwerkdeel
+
+            * `maatschappelijke_activiteit` - Maatschappelijke activiteit
+
+            * `medewerker` - Medewerker
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `openbare_ruimte` - Openbare ruimte
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `pand` - Pand
+
+            * `spoorbaandeel` - Spoorbaandeel
+
+            * `status` - Status
+
+            * `terreindeel` - Terreindeel
+
+            * `terrein_gebouwd_object` - Terrein gebouwd object
+
+            * `vestiging` - Vestiging
+
+            * `waterdeel` - Waterdeel
+
+            * `wegdeel` - Wegdeel
+
+            * `wijk` - Wijk
+
+            * `woonplaats` - Woonplaats
+
+            * `woz_deelobject` - Woz deel object
+
+            * `woz_object` - Woz object
+
+            * `woz_waarde` - Woz waarde
+
+            * `zakelijk_recht` - Zakelijk recht
+
+            * `overige` - Overige'
+          title: object type
+        objectTypeOverige:
+          type: string
+          description:
+            Beschrijft het type OBJECT als `objectType` de waarde "overige"
+            heeft.
+          title: object type overige
+          pattern: '[a-z\_]+'
+          maxLength: 100
+        objectTypeOverigeDefinitie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeOverigeDefinitie'
+          nullable: true
+          title: definitie object type overige
+          description:
+            'Verwijzing naar het schema van het type OBJECT als `objectType`
+            de waarde "overige" heeft.
+
+
+            * De URL referentie moet naar een JSON endpoint   wijzen waarin het objecttype
+            gedefinieerd is, inclusief het   [JSON-schema](https://json-schema.org/).
+
+            * Gebruik het `schema` attribuut om te verwijzen naar het schema binnen   de
+            objecttype resource (deze gebruikt het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+            * Gebruik het `objectData` attribuut om te verwijzen naar de gegevens   binnen
+            het OBJECT. Deze gebruikt ook het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+
+            Indien je hier gebruikt van maakt, dan moet je een OBJECT url opgeven
+            en is het gebruik van objectIdentificatie niet mogelijk. De opgegeven
+            OBJECT url wordt gevalideerd tegen het schema van het opgegeven objecttype.'
+        relatieomschrijving:
+          type: string
+          description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
+          title: relatieomschrijving
+          maxLength: 80
+        _expand:
+            $ref: '#/components/schemas/ZaakObjectEmbedded'
+      required:
+        - objectType
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: objectType
+        mapping:
+          adres: '#/components/schemas/adres_ZaakObjectExpanded'
+          besluit: '#/components/schemas/besluit_ZaakObjectExpanded'
+          buurt: '#/components/schemas/buurt_ZaakObjectExpanded'
+          enkelvoudig_document: '#/components/schemas/enkelvoudig_document_ZaakObjectExpanded'
+          gemeente: '#/components/schemas/gemeente_ZaakObjectExpanded'
+          gemeentelijke_openbare_ruimte: '#/components/schemas/gemeentelijke_openbare_ruimte_ZaakObjectExpanded'
+          huishouden: '#/components/schemas/huishouden_ZaakObjectExpanded'
+          inrichtingselement: '#/components/schemas/inrichtingselement_ZaakObjectExpanded'
+          kadastrale_onroerende_zaak: '#/components/schemas/kadastrale_onroerende_zaak_ZaakObjectExpanded'
+          kunstwerkdeel: '#/components/schemas/kunstwerkdeel_ZaakObjectExpanded'
+          maatschappelijke_activiteit: '#/components/schemas/maatschappelijke_activiteit_ZaakObjectExpanded'
+          medewerker: '#/components/schemas/medewerker_ZaakObjectExpanded'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_ZaakObjectExpanded'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_ZaakObjectExpanded'
+          openbare_ruimte: '#/components/schemas/openbare_ruimte_ZaakObjectExpanded'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_ZaakObjectExpanded'
+          pand: '#/components/schemas/pand_ZaakObjectExpanded'
+          spoorbaandeel: '#/components/schemas/spoorbaandeel_ZaakObjectExpanded'
+          status: '#/components/schemas/status_ZaakObjectExpanded'
+          terreindeel: '#/components/schemas/terreindeel_ZaakObjectExpanded'
+          terrein_gebouwd_object: '#/components/schemas/terrein_gebouwd_object_ZaakObjectExpanded'
+          vestiging: '#/components/schemas/vestiging_ZaakObjectExpanded'
+          waterdeel: '#/components/schemas/waterdeel_ZaakObjectExpanded'
+          wegdeel: '#/components/schemas/wegdeel_ZaakObjectExpanded'
+          wijk: '#/components/schemas/wijk_ZaakObjectExpanded'
+          woonplaats: '#/components/schemas/woonplaats_ZaakObjectExpanded'
+          woz_deelobject: '#/components/schemas/woz_deelobject_ZaakObjectExpanded'
+          woz_object: '#/components/schemas/woz_object_ZaakObjectExpanded'
+          woz_waarde: '#/components/schemas/woz_waarde_ZaakObjectExpanded'
+          zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObjectExpanded'
+          overige: '#/components/schemas/overige_ZaakObjectExpanded'
     ZaakObjectEmbedded:
       type: object
-      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'
@@ -14968,6 +15308,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectAdres'
+    adres_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectAdres'
     adres_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -14975,6 +15319,9 @@ components:
     besluit_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+    besluit_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
     besluit_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15017,6 +15364,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectBuurt'
+    buurt_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectBuurt'
     buurt_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15024,12 +15375,19 @@ components:
     enkelvoudig_document_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+    enkelvoudig_document_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
     enkelvoudig_document_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
     gemeente_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeente'
+    gemeente_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectGemeente'
     gemeente_PatchedZaakObject:
       allOf:
@@ -15039,6 +15397,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectGemeentelijkeOpenbareRuimte'
+    gemeentelijke_openbare_ruimte_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeentelijkeOpenbareRuimte'
     gemeentelijke_openbare_ruimte_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15046,6 +15408,10 @@ components:
     huishouden_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectHuishouden'
+    huishouden_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectHuishouden'
     huishouden_PatchedZaakObject:
       allOf:
@@ -15055,6 +15421,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectInrichtingselement'
+    inrichtingselement_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectInrichtingselement'
     inrichtingselement_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15062,6 +15432,10 @@ components:
     kadastrale_onroerende_zaak_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKadastraleOnroerendeZaak'
+    kadastrale_onroerende_zaak_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectKadastraleOnroerendeZaak'
     kadastrale_onroerende_zaak_PatchedZaakObject:
       allOf:
@@ -15071,6 +15445,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectKunstwerkdeel'
+    kunstwerkdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKunstwerkdeel'
     kunstwerkdeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15078,6 +15456,10 @@ components:
     maatschappelijke_activiteit_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectMaatschappelijkeActiviteit'
+    maatschappelijke_activiteit_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectMaatschappelijkeActiviteit'
     maatschappelijke_activiteit_PatchedZaakObject:
       allOf:
@@ -15087,9 +15469,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
     medewerker_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
     medewerker_PatchedZaakObject:
       allOf:
@@ -15099,9 +15489,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
     natuurlijk_persoon_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
     natuurlijk_persoon_PatchedZaakObject:
       allOf:
@@ -15111,9 +15509,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
     niet_natuurlijk_persoon_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
     niet_natuurlijk_persoon_PatchedZaakObject:
       allOf:
@@ -15319,6 +15725,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectOpenbareRuimte'
+    openbare_ruimte_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOpenbareRuimte'
     openbare_ruimte_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15327,9 +15737,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
     organisatorische_eenheid_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
     organisatorische_eenheid_PatchedZaakObject:
       allOf:
@@ -15339,6 +15757,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectOverige'
+    overige_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOverige'
     overige_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15346,6 +15768,10 @@ components:
     pand_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectPand'
+    pand_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectPand'
     pand_PatchedZaakObject:
       allOf:
@@ -15355,6 +15781,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectSpoorbaandeel'
+    spoorbaandeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectSpoorbaandeel'
     spoorbaandeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15362,32 +15792,51 @@ components:
     status_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+    status_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
     status_PatchedZaakObject:
       allOf:
-        - $ref: '#/components/schemas/PatchedZaakObject'    
+        - $ref: '#/components/schemas/PatchedZaakObject'
     terrein_gebouwd_object_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
+    terrein_gebouwd_object_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
     terrein_gebouwd_object_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
     terreindeel_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
+    terreindeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
     terreindeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
     vestiging_Rol:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
     vestiging_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
     vestiging_PatchedZaakObject:
       allOf:
@@ -15397,37 +15846,57 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'
+    waterdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'
     waterdeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel' 
     wegdeel_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
+    wegdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
     wegdeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
     wijk_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWijk'
+    wijk_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'
     wijk_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'   
     woonplaats_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
+    woonplaats_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
     woonplaats_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
     woz_deelobject_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozDeelobject'
+    woz_deelobject_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectWozDeelobject'
     woz_deelobject_PatchedZaakObject:
       allOf:
@@ -15437,13 +15906,21 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
+    woz_object_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
     woz_object_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
     woz_waarde_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozWaarde'
+    woz_waarde_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectWozWaarde'
     woz_waarde_PatchedZaakObject:
       allOf:
@@ -15452,6 +15929,10 @@ components:
     zakelijk_recht_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectZakelijkRecht'
+    zakelijk_recht_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectZakelijkRecht'
     zakelijk_recht_PatchedZaakObject:
       allOf:

--- a/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml
@@ -13073,7 +13073,7 @@ components:
     #       _expand:
     #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
-      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14597,7 +14597,7 @@ components:
     #           $ref: '#/components/schemas/ZaakObjectEmbedded'
     ZaakObjectEmbedded:
       type: object
-      description: "**LET OP: Deze expand mag alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'

--- a/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
@@ -1,0 +1,15970 @@
+openapi: 3.0.3
+info:
+  title: Zaken API
+  version: 1.5.2
+  description: " <b><i>Met expand mechanisme in plain json</i></b>
+  
+    
+    Een API om een zaakregistratiecomponent (ZRC) te benaderen.
+
+
+    De ZAAK is het kernobject in deze API, waaraan verschillende andere
+
+    resources gerelateerd zijn. De Zaken API werkt samen met andere API's voor
+
+    Zaakgericht werken om tot volledige functionaliteit te komen.
+
+
+    **Wat is nieuw?**
+
+    * Query parameters en zoekvelden voor archivering.
+
+
+    **Afhankelijkheden**
+
+
+    Deze API is afhankelijk van:
+
+
+    * Catalogi API
+
+    * Notificaties API
+
+    * Documenten API *(optioneel)*
+
+    * Besluiten API *(optioneel)*
+
+    * Autorisaties API *(optioneel)*
+
+
+    **Autorisatie**
+
+
+    Deze API vereist autorisatie. Je kan de
+
+    [token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens te
+
+    genereren.
+
+
+    ### Notificaties
+
+
+    Deze API publiceert notificaties op het kanaal `zaken`.
+
+
+    **Main resource**
+
+
+    `zaak`
+
+
+
+
+    **Kenmerken**
+
+
+    * `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie
+    die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers en voldoen
+    aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
+
+    * `zaaktype`: URL-referentie naar het ZAAKTYPE (in de Catalogi API) in de CATALOGUS
+    waar deze voorkomt
+
+    * `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het zaakdossier
+    van de ZAAK voor de openbaarheid bestemd is.
+
+
+    **Resources en acties**
+
+    - `zaak`: create, update, destroy
+
+    - `status`: create
+
+    - `zaakobject`: create, update, destroy
+
+    - `zaakinformatieobject`: create
+
+    - `zaakeigenschap`: create, update, destroy
+
+    - `klantcontact`: create
+
+    - `rol`: create, destroy
+
+    - `resultaat`: create, update, destroy
+
+    - `zaakbesluit`: create
+
+    - `zaakcontactmoment`: create
+
+    - `zaakverzoek`: create
+
+
+
+    **Handige links**
+
+
+    * [Documentatie](https://vng-realisatie.github.io/gemma-zaken/standaard)
+
+    * [Zaakgericht werken](https://vng-realisatie.github.io/gemma-zaken)
+
+    "
+  contact:
+    email: standaarden.ondersteuning@vng.nl
+    url: https://vng-realisatie.github.io/gemma-zaken
+  license:
+    name: EUPL 1.2
+    url: https://opensource.org/licenses/EUPL-1.2
+paths:
+  /klantcontacten:
+    get:
+      operationId: klantcontact_list
+      description: 'Alle KLANTCONTACTen opvragen.
+
+
+        **DEPRECATED**: gebruik de contactmomenten API in plaats van deze endpoint.'
+      summary: 'Alle KLANTCONTACTen opvragen. '
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: page
+          required: false
+          in: query
+          description: Een pagina binnen de gepagineerde set resultaten.
+          schema:
+            type: integer
+      tags:
+        - klantcontacten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      deprecated: true
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedKlantContactList'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: klantcontact_create
+      description:
+        'Indien geen identificatie gegeven is, dan wordt deze automatisch
+        gegenereerd.
+
+
+        **DEPRECATED**: gebruik de contactmomenten API in plaats van deze endpoint.'
+      summary: Maak een KLANTCONTACT bij een ZAAK aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - klantcontacten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KlantContact'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      deprecated: true
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KlantContact'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /klantcontacten/{uuid}:
+    get:
+      operationId: klantcontact_retrieve
+      description: 'Een specifieke KLANTCONTACT opvragen.
+
+
+        **DEPRECATED**: gebruik de contactmomenten API in plaats van deze endpoint.'
+      summary: Een specifieke KLANTCONTACT opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+      tags:
+        - klantcontacten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      deprecated: true
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KlantContact'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /resultaten:
+    get:
+      operationId: resultaat_list
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
+      summary: Alle RESULTAATen van ZAAKen opvragen.
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: resultaattype
+          required: false
+          in: query
+          description: URL-referentie naar het RESULTAATTYPE (in de Catalogi API).
+          schema:
+            type: string
+            format: uri
+        - name: page
+          required: false
+          in: query
+          description: Een pagina binnen de gepagineerde set resultaten.
+          schema:
+            type: integer
+      tags:
+        - resultaten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResultaatList'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: resultaat_create
+      description: '**Er wordt gevalideerd op:**
+
+        - geldigheid URL naar de ZAAK
+
+        - geldigheid URL naar het RESULTAATTYPE'
+      summary: Maak een RESULTAAT bij een ZAAK aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - resultaten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Resultaat'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /resultaten/{uuid}:
+    get:
+      operationId: resultaat_retrieve
+      description: Een specifieke RESULTAAT opvragen.
+      summary: Een specifieke RESULTAAT opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - resultaten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    put:
+      operationId: resultaat_update
+      description:
+        "**Er wordt gevalideerd op** \n- geldigheid URL naar de ZAAK\n\
+        - het RESULTAATTYPE mag niet gewijzigd worden"
+      summary: Werk een RESULTAAT in zijn geheel bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - resultaten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Resultaat'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    patch:
+      operationId: resultaat_partial_update
+      description:
+        "**Er wordt gevalideerd op** \n- geldigheid URL naar de ZAAK\n\
+        - het RESULTAATTYPE mag niet gewijzigd worden"
+      summary: Werk een RESULTAAT deels bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - resultaten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedResultaat'
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resultaat'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: resultaat_destroy
+      description: Verwijder een RESULTAAT van een ZAAK.
+      summary: Verwijder een RESULTAAT van een ZAAK.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - resultaten
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    head:
+      operationId: resultaat_headers
+      description: Vraag de headers op die je bij een GET request zou krijgen.
+      summary: 'De headers voor een specifiek(e) RESULTAAT opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - resultaten
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          description: OK
+  /rollen:
+    get:
+      operationId: rol_list
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
+      summary: Alle ROLlen bij ZAAKen opvragen.
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: betrokkene
+          required: false
+          in: query
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: betrokkeneType
+          required: false
+          in: query
+          description: Type van de `betrokkene`.
+          schema:
+            type: string
+            enum:
+              - natuurlijk_persoon
+              - niet_natuurlijk_persoon
+              - vestiging
+              - organisatorische_eenheid
+              - medewerker
+        - name: betrokkeneIdentificatie__natuurlijkPersoon__inpBsn
+          required: false
+          in: query
+          description:
+            Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene
+            bepalingen burgerservicenummer.
+          schema:
+            type: string
+        - name: betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie
+          required: false
+          in: query
+          description:
+            Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NATUURLIJK PERSOON
+          schema:
+            type: string
+        - name: betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer
+          required: false
+          in: query
+          description: Het administratienummer van de persoon, bedoeld in de Wet BRP
+          schema:
+            type: string
+        - name: betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId
+          required: false
+          in: query
+          description:
+            Het door een kamer toegekend uniek nummer voor de INGESCHREVEN
+            NIET-NATUURLIJK PERSOON
+          schema:
+            type: string
+        - name: betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie
+          required: false
+          in: query
+          description:
+            Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NIET-NATUURLIJK PERSOON
+          schema:
+            type: string
+        - name: betrokkeneIdentificatie__vestiging__vestigingsNummer
+          required: false
+          in: query
+          description: Een korte unieke aanduiding van de Vestiging.
+          schema:
+            type: string
+        - name: betrokkeneIdentificatie__organisatorischeEenheid__identificatie
+          required: false
+          in: query
+          description: Een korte identificatie van de organisatorische eenheid.
+          schema:
+            type: string
+        - name: betrokkeneIdentificatie__medewerker__identificatie
+          required: false
+          in: query
+          description: Een korte unieke aanduiding van de MEDEWERKER.
+          schema:
+            type: string
+        - name: roltype
+          required: false
+          in: query
+          description: URL-referentie naar een roltype binnen het ZAAKTYPE van de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: omschrijving
+          required: false
+          in: query
+          description: Omschrijving van de aard van de ROL, afgeleid uit het ROLTYPE.
+          schema:
+            type: string
+        - name: omschrijvingGeneriek
+          required: false
+          in: query
+          description:
+            Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
+            uit het ROLTYPE.
+          schema:
+            type: string
+            enum:
+              - adviseur
+              - behandelaar
+              - belanghebbende
+              - beslisser
+              - initiator
+              - klantcontacter
+              - zaakcoordinator
+              - mede_initiator
+        - name: page
+          required: false
+          in: query
+          description: Een pagina binnen de gepagineerde set resultaten.
+          schema:
+            type: integer
+      tags:
+        - rollen
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRolList'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: rol_create
+      description: Maak een ROL aan bij een ZAAK.
+      summary: Maak een ROL aan bij een ZAAK.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - rollen
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Rol'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rol'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /rollen/{uuid}:
+    get:
+      operationId: rol_retrieve
+      description: Een specifieke ROL bij een ZAAK opvragen.
+      summary: Een specifieke ROL bij een ZAAK opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - rollen
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rol'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: rol_destroy
+      description: Verwijder een ROL van een ZAAK.
+      summary: Verwijder een ROL van een ZAAK.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - rollen
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    head:
+      operationId: rol_headers
+      description: Vraag de headers op die je bij een GET request zou krijgen.
+      summary: 'De headers voor een specifiek(e) ROL opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - rollen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          description: OK
+  /statussen:
+    get:
+      operationId: status_list
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
+      summary: Alle STATUSsen bij ZAAKen opvragen.
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: statustype
+          required: false
+          in: query
+          description: URL-referentie naar het STATUSTYPE (in de Catalogi API).
+          schema:
+            type: string
+            format: uri
+        - name: indicatieLaatstGezetteStatus
+          required: false
+          in: query
+          description:
+            Het gegeven is afleidbaar uit de historie van de attribuutsoort
+            Datum status gezet van van alle statussen bij de desbetreffende zaak.
+          schema:
+            type: string
+        - name: page
+          required: false
+          in: query
+          description: Een pagina binnen de gepagineerde set resultaten.
+          schema:
+            type: integer
+      tags:
+        - statussen
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedStatusList'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: status_create
+      description: '**Er wordt gevalideerd op**
+
+        - geldigheid URL naar de ZAAK
+
+        - geldigheid URL naar het STATUSTYPE
+
+        - indien het de eindstatus betreft, dan moet het attribuut `indicatieGebruiksrecht`
+        gezet zijn op alle informatieobjecten dieaan de zaak gerelateerd zijn
+
+
+        **Opmerkingen**
+
+        - Indien het statustype de eindstatus is (volgens het ZTC), dan wordt de zaak
+        afgesloten door de einddatum te zetten.'
+      summary: Maak een STATUS aan voor een ZAAK.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - statussen
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Status'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.aanmaken | zaken.statussen.toevoegen | zaken.heropenen)
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusRequestbody'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /statussen/{uuid}:
+    get:
+      operationId: status_retrieve
+      description: Een specifieke STATUS van een ZAAK opvragen.
+      summary: Een specifieke STATUS van een ZAAK opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - statussen
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    head:
+      operationId: status_headers
+      description: Vraag de headers op die je bij een GET request zou krijgen.
+      summary: 'De headers voor een specifiek(e) STATUS opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - statussen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          description: OK
+  /zaakcontactmomenten:
+    get:
+      operationId: zaakcontactmoment_list
+      description: Alle ZAAKCONTACTMOMENTen opvragen.
+      summary: Alle ZAAKCONTACTMOMENTen opvragen.
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: contactmoment
+          required: false
+          in: query
+          description:
+            URL-referentie naar het CONTACTMOMENT (in de Klantinteractie
+            API)
+          schema:
+            type: string
+            format: uri
+      tags:
+        - zaakcontactmomenten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakContactMoment'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: zaakcontactmoment_create
+      description: '**Er wordt gevalideerd op:**
+
+        - geldigheid URL naar het CONTACTMOMENT'
+      summary: Maak een ZAAKCONTACTMOMENT aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakcontactmomenten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakContactMoment'
+        required: true
+      security:
+        - JWT-Claims:
+            - zaken.bijwerken
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakContactMoment'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaakcontactmomenten/{uuid}:
+    get:
+      operationId: zaakcontactmoment_retrieve
+      description: Een specifiek ZAAKCONTACTMOMENT opvragen.
+      summary: 'Een specifiek ZAAKCONTACTMOMENT opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+      tags:
+        - zaakcontactmomenten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakContactMoment'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: zaakcontactmoment_destroy
+      description: Verwijder een ZAAKCONTACTMOMENT.
+      summary: Verwijder een ZAAKCONTACTMOMENT.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakcontactmomenten
+      security:
+        - JWT-Claims:
+            - zaken.bijwerken
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaakinformatieobjecten:
+    get:
+      operationId: zaakinformatieobject_list
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
+      summary: 'Alle ZAAK-INFORMATIEOBJECT relaties opvragen '
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: informatieobject
+          required: false
+          in: query
+          description:
+            URL-referentie naar het INFORMATIEOBJECT (in de Documenten API),
+            waar ook de relatieinformatie opgevraagd kan worden.
+          schema:
+            type: string
+            format: uri
+      tags:
+        - zaakinformatieobjecten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakInformatieObject'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: zaakinformatieobject_create
+      description:
+        "Maak een ZAAK-INFORMATIEOBJECT relatie aan.\n\n**Er wordt gevalideerd\
+        \ op**\n- geldigheid zaak URL\n- geldigheid informatieobject URL\n- `zaak.archiefstatus`\
+        \ moet gelijk zijn aan 'nog_te_archiveren' \n- de combinatie informatieobject\
+        \ en zaak moet uniek zijn\n\n**Opmerkingen**\n- De registratiedatum wordt\
+        \ door het systeem op 'NU' gezet. De `aardRelatie` wordt ook door het systeem\
+        \ gezet.\n- Bij het aanmaken wordt ook in de Documenten API de gespiegelde\
+        \ relatie aangemaakt, echter zonder de relatie-informatie.\n"
+      summary: Maak een ZAAK-INFORMATIEOBJECT relatie aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakinformatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakInformatieObject'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.aanmaken | zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaakinformatieobjecten/{uuid}:
+    get:
+      operationId: zaakinformatieobject_retrieve
+      description: Een specifieke ZAAK-INFORMATIEOBJECT relatie opvragen.
+      summary: Een specifieke ZAAK-INFORMATIEOBJECT relatie opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - zaakinformatieobjecten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    put:
+      operationId: zaakinformatieobject_update
+      description:
+        "Je mag enkel de gegevens van de relatie bewerken, en niet de relatie\
+        \ zelf aanpassen.\n\n**Er wordt gevalideerd op** \n- informatieobject URL\
+        \ en zaak URL mogen niet veranderen"
+      summary: Werk een ZAAK-INFORMATIEOBJECT relatie in zijn geheel bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakinformatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakInformatieObject'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    patch:
+      operationId: zaakinformatieobject_partial_update
+      description:
+        "Je mag enkel de gegevens van de relatie bewerken, en niet de relatie\
+        \ zelf aanpassen.\n\n**Er wordt gevalideerd op** \n- informatieobject URL\
+        \ en zaak URL mogen niet veranderen"
+      summary: Werk een ZAAK-INFORMATIEOBJECT relatie deels bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakinformatieobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedZaakInformatieObject'
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakInformatieObject'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: zaakinformatieobject_destroy
+      description:
+        De gespiegelde relatie in de Documenten API wordt door de Zaken
+        API verwijderd. Consumers kunnen dit niet handmatig doen.
+      summary: Verwijder een ZAAK-INFORMATIEOBJECT relatie.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakinformatieobjecten
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken | zaken.verwijderen)
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    head:
+      operationId: zaakinformatieobject_headers
+      description: Vraag de headers op die je bij een GET request zou krijgen.
+      summary: 'De headers voor een specifiek(e) ZAAKINFORMATIEOBJECT opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - zaakinformatieobjecten
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          description: OK
+  /zaakobjecten:
+    get:
+      operationId: zaakobject_list
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
+      summary: Alle ZAAKOBJECTen opvragen.
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: object
+          required: false
+          in: query
+          description: URL-referentie naar de resource die het OBJECT beschrijft.
+          schema:
+            type: string
+            format: uri
+        - name: objectType
+          required: false
+          in: query
+          description:
+            Beschrijft het type OBJECT gerelateerd aan de ZAAK. Als er geen
+            passend type is, dan moet het type worden opgegeven onder `objectTypeOverige`.
+          schema:
+            type: string
+            enum:
+              - adres
+              - besluit
+              - buurt
+              - enkelvoudig_document
+              - gemeente
+              - gemeentelijke_openbare_ruimte
+              - huishouden
+              - inrichtingselement
+              - kadastrale_onroerende_zaak
+              - kunstwerkdeel
+              - maatschappelijke_activiteit
+              - medewerker
+              - natuurlijk_persoon
+              - niet_natuurlijk_persoon
+              - openbare_ruimte
+              - organisatorische_eenheid
+              - pand
+              - spoorbaandeel
+              - status
+              - terreindeel
+              - terrein_gebouwd_object
+              - vestiging
+              - waterdeel
+              - wegdeel
+              - wijk
+              - woonplaats
+              - woz_deelobject
+              - woz_object
+              - woz_waarde
+              - zakelijk_recht
+              - overige
+        - name: page
+          required: false
+          in: query
+          description: Een pagina binnen de gepagineerde set resultaten.
+          schema:
+            type: integer
+      tags:
+        - zaakobjecten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedZaakObjectList'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: zaakobject_create
+      description: 'Maak een ZAAKOBJECT aan.
+
+
+        **Er wordt gevalideerd op**
+
+        - Indien de `object` URL opgegeveven is, dan moet deze een geldige  response
+        (HTTP 200) geven.
+
+        - Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd tegen de `objectType`
+        discriminator.'
+      summary: Maak een ZAAKOBJECT aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakObject'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.aanmaken | zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaakobjecten/{uuid}:
+    get:
+      operationId: zaakobject_retrieve
+      description: Een specifieke ZAAKOBJECT opvragen.
+      summary: Een specifieke ZAAKOBJECT opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - zaakobjecten
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    put:
+      operationId: zaakobject_update
+      description:
+        "**Er wordt gevalideerd op** \n- De attributen `zaak`, `object`\
+        \ en `objectType` mogen niet gewijzigd worden.\n- Indien opgegeven, dan wordt\
+        \ `objectIdentificatie` gevalideerd tegen de objectType discriminator."
+      summary: Werk een ZAAKOBJECT zijn geheel bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+      tags:
+        - zaakobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakObject'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    patch:
+      operationId: zaakobject_partial_update
+      description:
+        "**Er wordt gevalideerd op** \n- De attributen `zaak`, `object`\
+        \ en `objectType` mogen niet gewijzigd worden.\n- Indien opgegeven, dan wordt\
+        \ `objectIdentificatie` gevalideerd tegen de objectType discriminator."
+      summary: Werk een ZAAKOBJECT deels bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+      tags:
+        - zaakobjecten
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedZaakObject'
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: zaakobject_destroy
+      description:
+        Verbreek de relatie tussen een ZAAK en een OBJECT door de ZAAKOBJECT
+        resource te verwijderen.
+      summary: Verwijder een ZAAKOBJECT.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+      tags:
+        - zaakobjecten
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken | zaken.verwijderen)
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    head:
+      operationId: zaakobject_headers
+      description: Vraag de headers op die je bij een GET request zou krijgen.
+      summary: 'De headers voor een specifiek(e) ZAAKOBJECT opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+      tags:
+        - zaakobjecten
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          description: OK
+  /zaakverzoeken:
+    get:
+      operationId: zaakverzoek_list
+      description: Alle ZAAK-VERZOEKen opvragen.
+      summary: Alle ZAAK-VERZOEKen opvragen.
+      parameters:
+        - name: zaak
+          required: false
+          in: query
+          description: URL-referentie naar de ZAAK.
+          schema:
+            type: string
+            format: uri
+        - name: verzoek
+          required: false
+          in: query
+          description: URL-referentie naar het VERZOEK (in de Klantinteractie API)
+          schema:
+            type: string
+            format: uri
+      tags:
+        - zaakverzoeken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakVerzoek'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: zaakverzoek_create
+      description: '**Er wordt gevalideerd op**
+
+        - geldigheid URL naar de VERZOEK'
+      summary: Maak een ZAAK-VERZOEK aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakverzoeken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakVerzoek'
+        required: true
+      security:
+        - JWT-Claims:
+            - zaken.bijwerken
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakVerzoek'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaakverzoeken/{uuid}:
+    get:
+      operationId: zaakverzoek_retrieve
+      description: Een specifieke ZAAK-VERZOEK opvragen.
+      summary: Een specifieke ZAAK-VERZOEK opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+      tags:
+        - zaakverzoeken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakVerzoek'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: zaakverzoek_destroy
+      description: Verwijder een ZAAK-VERZOEK.
+      summary: Verwijder een ZAAK-VERZOEK.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+      tags:
+        - zaakverzoeken
+      security:
+        - JWT-Claims:
+            - zaken.bijwerken
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaken:
+    get:
+      operationId: zaak_list
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
+      summary: Alle ZAAKen opvragen.
+      parameters:
+        - name: identificatie
+          required: false
+          in: query
+          description:
+            De unieke identificatie van de ZAAK binnen de organisatie die
+            verantwoordelijk is voor de behandeling van de ZAAK.
+          schema:
+            type: string
+            example: "zaak123"
+        - name: bronorganisatie
+          required: false
+          in: query
+          description:
+            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie
+            die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers
+            en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
+          schema:
+            type: string
+            example: "000000000"
+        - name: bronorganisatie__in
+          required: false
+          in: query
+          description: Multiple values may be separated by commas.
+          schema:
+            type: array
+            items:
+              type: string
+            example: ["000000000","479559740","875883461"]
+          style: form
+          explode: false
+        - name: zaaktype
+          required: false
+          in: query
+          description:
+            URL-referentie naar het ZAAKTYPE (in de Catalogi API) in de CATALOGUS
+            waar deze voorkomt
+          schema:
+            type: string
+            format: uri
+            example: "https://catalogi-api.test.vng.cloud/api/v1/zaaktypen/e80b7507-199a-484c-ad49-c41a1e43a6e7"
+        - name: archiefnominatie
+          required: false
+          in: query
+          description:
+            Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+          schema:
+            type: string
+            enum:
+              - blijvend_bewaren
+              - vernietigen
+            example: "blijvend_bewaren"
+        - name: archiefnominatie__in
+          required: false
+          in: query
+          description: Multiple values may be separated by commas.
+          schema:
+            type: array
+            items:
+              type: string
+            example: ["blijvend_bewaren", "vernietigen"]
+          style: form
+          explode: false
+        - name: archiefactiedatum
+          required: false
+          in: query
+          description:
+            De datum waarop het gearchiveerde zaakdossier vernietigd moet
+            worden dan wel overgebracht moet worden naar een archiefbewaarplaats. Wordt
+            automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT aan
+            deze ZAAK indien nog leeg.
+          schema:
+            type: string
+            example: "2019-01-02"
+        - name: archiefactiedatum__isnull
+          required: false
+          in: query
+          description: De archiefactiedatum is leeg.
+          schema:
+            type: boolean
+            example: false
+        - name: archiefactiedatum__lt
+          required: false
+          in: query
+          description: De archiefactiedatum is kleiner dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2020-01-02"
+        - name: archiefactiedatum__gt
+          required: false
+          in: query
+          description: De archiefactiedatum is groter dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2018-01-02"
+        - name: archiefstatus
+          required: false
+          in: query
+          description:
+            Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+          schema:
+            type: string
+            enum:
+              - nog_te_archiveren
+              - gearchiveerd
+              - gearchiveerd_procestermijn_onbekend
+              - overgedragen
+            example: "nog_te_archiveren"
+        - name: archiefstatus__in
+          required: false
+          in: query
+          description: Multiple values may be separated by commas.
+          schema:
+            type: array
+            items:
+              type: string
+            example: ["nog_te_archiveren","gearchiveerd","gearchiveerd_procestermijn_onbekend","overgedragen"]
+          style: form
+          explode: false
+        - name: startdatum
+          required: false
+          in: query
+          description: De datum waarop met de uitvoering van de zaak is gestart
+          schema:
+            type: string
+            example: "2017-01-02"
+        - name: startdatum__gt
+          required: false
+          in: query
+          description: De startdatum is groter dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2018-01-02"
+        - name: startdatum__gte
+          required: false
+          in: query
+          description: De startdatum is groter dan of gelijk dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2016-01-02"
+        - name: startdatum__lt
+          required: false
+          in: query
+          description: De startdatum is kleiner dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2018-01-02"
+        - name: startdatum__lte
+          required: false
+          in: query
+          description: De startdatum is kleiner of gelijk dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2018-01-02"
+        - name: registratiedatum
+          required: false
+          in: query
+          description:
+            De datum waarop de zaakbehandelende organisatie de ZAAK heeft
+            geregistreerd. Indien deze niet opgegeven wordt, wordt de datum van vandaag
+            gebruikt.
+          schema:
+            type: string
+            example: "2015-01-02"
+        - name: registratiedatum__gt
+          required: false
+          in: query
+          description:
+           De registratiedatum is groter dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2014-01-02"
+        - name: registratiedatum__lt
+          required: false
+          in: query
+          description:
+            De registratiedatum is kleiner dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2016-01-02"
+        - name: einddatum
+          required: false
+          in: query
+          description: De datum waarop de uitvoering van de zaak afgerond is.
+          schema:
+            type: string
+            example: "2022-01-02"
+        - name: einddatum__isnull
+          required: false
+          in: query
+          description: De einddatum is leeg.
+          schema:
+            type: boolean
+            example: false
+        - name: einddatum__gt
+          required: false
+          in: query
+          description: De einddatum is groter dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2021-01-02"
+        - name: einddatum__lt
+          required: false
+          in: query
+          description: De einddatum is kleiner dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2023-01-02"
+        - name: einddatumGepland
+          required: false
+          in: query
+          description:
+            De datum waarop volgens de planning verwacht wordt dat de zaak
+            afgerond wordt.
+          schema:
+            type: string
+            example: "2022-01-02"
+        - name: einddatumGepland__gt
+          required: false
+          in: query
+          description:
+            De geplande einddatum is groter dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2021-01-02"
+        - name: einddatumGepland__lt
+          required: false
+          in: query
+          description:
+            De geplande einddatum is kleiner dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2024-01-02"
+        - name: uiterlijkeEinddatumAfdoening
+          required: false
+          in: query
+          description:
+            De laatste datum waarop volgens wet- en regelgeving de zaak afgerond
+            dient te zijn.
+          schema:
+            type: string
+            example: "2024-01-02"
+        - name: uiterlijkeEinddatumAfdoening__gt
+          required: false
+          in: query
+          description:
+            De uiterlijke einddatumafdoening is groter dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2023-01-02"
+        - name: uiterlijkeEinddatumAfdoening__lt
+          required: false
+          in: query
+          description:
+            De uiterlijke einddatumafdoening is kleiner dan de opgegeven datum.
+          schema:
+            type: string
+            example: "2025-01-02"
+        - name: rol__betrokkeneType
+          required: false
+          in: query
+          description: Type van de `betrokkene`.
+          schema:
+            type: string
+            enum:
+              - natuurlijk_persoon
+              - niet_natuurlijk_persoon
+              - vestiging
+              - organisatorische_eenheid
+              - medewerker
+            example: "natuurlijk_persoon"
+        - name: rol__betrokkene
+          required: false
+          in: query
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          schema:
+            type: string
+            format: uri
+            example: "https://example.com"
+        - name: rol__omschrijvingGeneriek
+          required: false
+          in: query
+          description:
+            Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
+            uit het ROLTYPE.
+          schema:
+            type: string
+            enum:
+              - adviseur
+              - behandelaar
+              - belanghebbende
+              - beslisser
+              - initiator
+              - klantcontacter
+              - zaakcoordinator
+              - mede_initiator
+            example: "initiator"
+        - name: maximaleVertrouwelijkheidaanduiding
+          required: false
+          in: query
+          description:
+            Zaken met een vertrouwelijkheidaanduiding die beperkter is dan
+            de aangegeven aanduiding worden uit de resultaten gefiltered.
+          schema:
+            type: string
+            enum:
+              - openbaar
+              - beperkt_openbaar
+              - intern
+              - zaakvertrouwelijk
+              - vertrouwelijk
+              - confidentieel
+              - geheim
+              - zeer_geheim
+            example: "zaakvertrouwelijk"
+        - name: rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn
+          required: false
+          in: query
+          description:
+            Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene
+            bepalingen burgerservicenummer.
+          schema:
+            type: string
+            maxLength: 9
+            example: "123456789"
+        - name: rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie
+          required: false
+          in: query
+          description:
+            Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NATUURLIJK PERSOON
+          schema:
+            type: string
+            maxLength: 17
+            example: "123456789"
+        - name: rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer
+          required: false
+          in: query
+          description: Het administratienummer van de persoon, bedoeld in de Wet BRP
+          schema:
+            type: string
+            maxLength: 10
+            example: "123456789"
+        - name: rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId
+          required: false
+          in: query
+          description:
+            Het door een kamer toegekend uniek nummer voor de INGESCHREVEN
+            NIET-NATUURLIJK PERSOON
+          schema:
+            type: string
+            example: "123456789"
+        - name: rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie
+          required: false
+          in: query
+          description:
+            Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NIET-NATUURLIJK PERSOON
+          schema:
+            type: string
+            maxLength: 17
+            example: "123456789"
+        - name: rol__betrokkeneIdentificatie__vestiging__vestigingsNummer
+          required: false
+          in: query
+          description: Een korte unieke aanduiding van de Vestiging.
+          schema:
+            type: string
+            maxLength: 24
+            example: "123456789"
+        - name: rol__betrokkeneIdentificatie__medewerker__identificatie
+          required: false
+          in: query
+          description: Een korte unieke aanduiding van de MEDEWERKER.
+          schema:
+            type: string
+            maxLength: 24
+            example: "123456789"
+        - name: rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie
+          required: false
+          in: query
+          description: Een korte identificatie van de organisatorische eenheid.
+          schema:
+            type: string
+            example: "123456789"
+        - name: expand
+          in: query
+          description: Haal details van gelinkte resources direct op. Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt.
+          schema:
+            type: string
+            example: zaaktype, status, status.statustype, hoofdzaak.status.statustype, hoofdzaak.deelzaken.status.statustype
+        - name: ordering
+          required: false
+          in: query
+          description: Het veld waarop de resultaten geordend worden. Het minnetje betekent omgekeerde volgorde.
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - startdatum
+                - -startdatum
+                - einddatum
+                - -einddatum
+                - publicatiedatum
+                - -publicatiedatum
+                - archiefactiedatum
+                - -archiefactiedatum
+                - registratiedatum
+                - -registratiedatum
+                - identificatie
+                - -identificatie
+              example: "-startdatum"
+          style: form
+          explode: false
+        - name: page
+          required: false
+          in: query
+          description: Een pagina binnen de gepagineerde set resultaten.
+          schema:
+            type: integer
+            example: 1
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedZaakList'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: zaak_create
+      description:
+        'Indien geen identificatie gegeven is, dan wordt deze automatisch
+        gegenereerd. De identificatie moet uniek zijn binnen de bronorganisatie.
+
+
+        **Er wordt gevalideerd op:**
+
+        - geldigheid `zaaktype` URL - de resource moet opgevraagd kunnen worden uit
+        de Catalogi API en de vorm van een ZAAKTYPE hebben.
+
+        - `zaaktype` is geen concept (`zaaktype.concept = False`)
+
+        - `laatsteBetaaldatum` mag niet in de toekomst liggen.
+
+        - `laatsteBetaaldatum` mag niet gezet worden als de betalingsindicatie "nvt"
+        is.
+
+        - `barchiefnominatie` moet een waarde hebben indien archiefstatus niet de
+        waarde "nog_te_archiveren" heeft.
+
+        - `archiefactiedatum` moet een waarde hebben indien archiefstatus niet de
+        waarde "nog_te_archiveren" heeft.
+
+        - `archiefstatus` kan alleen een waarde anders dan "nog_te_archiveren" hebben
+        indien van alle gerelateeerde INFORMATIEOBJECTen het attribuut `status` de
+        waarde "gearchiveerd" heeft.'
+      summary: Maak een ZAAK aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Zaak'
+        required: true
+      security:
+        - JWT-Claims:
+            - zaken.aanmaken
+      responses:
+        '201':
+          headers:
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Zaak'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaken/{uuid}:
+    get:
+      operationId: zaak_retrieve
+      description: Een specifieke ZAAK opvragen.
+      summary: Een specifieke ZAAK opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+        - name: expand
+          in: query
+          description: Haal details van gelinkte resources direct op. Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt.
+          schema:
+            type: string
+            example: zaaktype, status, status.statustype, hoofdzaak.status.statustype, hoofdzaak.deelzaken.status.statustype
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakExpanded'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    put:
+      operationId: zaak_update
+      description:
+        "**Er wordt gevalideerd op** \n- `identificatie` mag niet gewijzigd worden.\n- `laatsteBetaaldatum`\
+        \ mag niet in de toekomst liggen.\n- `laatsteBetaaldatum` mag niet gezet worden\
+        \ als de betalingsindicatie\n\"nvt\" is.\n- `archiefnominatie` moet een waarde\
+        \ hebben indien `archiefstatus` niet de\nwaarde \"nog_te_archiveren\" heeft.\n\
+        - `archiefactiedatum` moet een waarde hebben indien `archiefstatus` niet de\n\
+        \ waarde \"nog_te_archiveren\" heeft.\n- `archiefstatus` kan alleen een waarde\
+        \ anders dan \"nog_te_archiveren\"\n hebben indien van alle gerelateeerde\
+        \ INFORMATIEOBJECTen het attribuut\n  `status` de waarde \"gearchiveerd\"\
+        \ heeft.\n**Opmerkingen**\n- er worden enkel zaken getoond van de zaaktypes\
+        \ waar u toe geautoriseerd\n bent.\n- indien een zaak heropend moet worden,\
+        \ doe dit dan door een nieuwe status\n toe te voegen die NIET de eindstatus\
+        \ is. Zie de `Status` resource."
+      summary: Werk een ZAAK in zijn geheel bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Zaak'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Zaak'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    patch:
+      operationId: zaak_partial_update
+      description:
+        "**Er wordt gevalideerd op** \n- `identificatie` mag niet gewijzigd worden.\n- `laatsteBetaaldatum`\
+        \ mag niet in de toekomst liggen.\n- `laatsteBetaaldatum` mag niet gezet worden\
+        \ als de betalingsindicatie\n\"nvt\" is.\n- `archiefnominatie` moet een waarde\
+        \ hebben indien `archiefstatus` niet de\nwaarde \"nog_te_archiveren\" heeft.\n\
+        - `archiefactiedatum` moet een waarde hebben indien `archiefstatus` niet de\n\
+        \ waarde \"nog_te_archiveren\" heeft.\n- `archiefstatus` kan alleen een waarde\
+        \ anders dan \"nog_te_archiveren\"\n hebben indien van alle gerelateeerde\
+        \ INFORMATIEOBJECTen het attribuut\n  `status` de waarde \"gearchiveerd\"\
+        \ heeft.\n**Opmerkingen**\n- er worden enkel zaken getoond van de zaaktypes\
+        \ waar u toe geautoriseerd\n bent.\n- indien een zaak heropend moet worden,\
+        \ doe dit dan door een nieuwe status\n toe te voegen die NIET de eindstatus\
+        \ is. Zie de `Status` resource."
+      summary: Werk een ZAAK deels bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedZaak'
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Zaak'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: zaak_destroy
+      description: '***De gerelateerde resources zijn hierbij***
+
+        - `zaak` - de deelzaken van de verwijderde hoofzaak
+
+        - `status` - alle statussen van de verwijderde zaak
+
+        - `resultaat` - het resultaat van de verwijderde zaak
+
+        - `rol` - alle rollen bij de zaak
+
+        - `zaakobject` - alle zaakobjecten bij de zaak
+
+        - `zaakeigenschap` - alle eigenschappen van de zaak
+
+        - `zaakkenmerk` - alle kenmerken van de zaak
+
+        - `zaakinformatieobject` - dit moet door-cascaden naar de Documenten API,
+        zie ook: https://github.com/VNG-Realisatie/gemma-zaken/issues/791 (TODO)
+
+        - `klantcontact` - alle klantcontacten bij een zaak'
+      summary: Verwijder een ZAAK.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.verwijderen
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    head:
+      operationId: zaak_headers
+      description: Vraag de headers op die je bij een GET request zou krijgen.
+      summary: 'De headers voor een specifiek(e) ZAAK opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - zaken
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          description: OK
+  /zaken/{zaak_uuid}/audittrail:
+    get:
+      operationId: audittrail_list
+      description: Alle audit trail regels behorend bij de ZAAK.
+      summary: Alle audit trail regels behorend bij de ZAAK.
+      parameters:
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - audittrails.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditTrail'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaken/{zaak_uuid}/audittrail/{uuid}:
+    get:
+      operationId: audittrail_retrieve
+      description: Een specifieke audit trail regel opvragen.
+      summary: 'Een specifieke audit trail regel opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke identificatie van de audit regel.
+            title: uuid
+          required: true
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - audittrails.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditTrail'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaken/{zaak_uuid}/besluiten:
+    get:
+      operationId: zaakbesluit_list
+      description: Alle ZAAKBESLUITen opvragen.
+      summary: Alle ZAAKBESLUITen opvragen.
+      parameters:
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakBesluit'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: zaakbesluit_create
+      description:
+        '**LET OP: Dit endpoint hoor je als consumer niet zelf aan te spreken.**
+
+
+        De Besluiten API gebruikt dit endpoint om relaties te synchroniseren, daarom
+        is dit endpoint in de Zaken API geimplementeerd.
+
+
+        **Er wordt gevalideerd op:**
+
+        - geldigheid URL naar de ZAAK'
+      summary: Maak een ZAAKBESLUIT aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakBesluit'
+        required: true
+      security:
+        - JWT-Claims:
+            - zaken.bijwerken
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakBesluit'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaken/{zaak_uuid}/besluiten/{uuid}:
+    get:
+      operationId: zaakbesluit_retrieve
+      description: Een specifiek ZAAKBESLUIT opvragen.
+      summary: 'Een specifiek ZAAKBESLUIT opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakBesluit'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: zaakbesluit_destroy
+      description:
+        '***LET OP: Dit endpoint hoor je als consumer niet zelf aan te
+        spreken.***
+
+
+        De Besluiten API gebruikt dit endpoint om relaties te synchroniseren, daarom
+        is dit endpoint in de Zaken API geimplementeerd.
+
+        '
+      summary: Verwijder een ZAAKBESLUIT.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.bijwerken
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaken/{zaak_uuid}/zaakeigenschappen:
+    get:
+      operationId: zaakeigenschap_list
+      description: Alle ZAAKEIGENSCHAPpen opvragen.
+      summary: 'Alle ZAAKEIGENSCHAPpen opvragen. '
+      parameters:
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZaakEigenschap'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    post:
+      operationId: zaakeigenschap_create
+      description: 'Maak een ZAAKEIGENSCHAP aan.
+
+
+        **Er wordt gevalideerd op:**
+
+        - geldigheid `eigenschap` URL - de resource moet opgevraagd kunnen worden
+        uit de Catalogi API en de vorm van een EIGENSCHAP hebben.
+
+        - de `eigenschap` moet bij het `ZAAK.zaaktype` horen'
+      summary: Maak een ZAAKEIGENSCHAP aan.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakEigenschap'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '201':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakEigenschap'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+  /zaken/{zaak_uuid}/zaakeigenschappen/{uuid}:
+    get:
+      operationId: zaakeigenschap_retrieve
+      description: Een specifieke ZAAKEIGENSCHAP opvragen.
+      summary: Een specifieke ZAAKEIGENSCHAP opvragen.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakEigenschap'
+          description: OK
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    put:
+      operationId: zaakeigenschap_update
+      description:
+        "**Er wordt gevalideerd op** \n- Alleen de `waarde` mag gewijzigd\
+        \ worden"
+      summary: Werk een ZAAKEIGENSCHAP in zijn geheel bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakEigenschap'
+        required: true
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakEigenschap'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    patch:
+      operationId: zaakeigenschap_partial_update
+      description:
+        "**Er wordt gevalideerd op** \n- Alleen de `waarde` mag gewijzigd\
+        \ worden"
+      summary: Werk een ZAAKEIGENSCHAP deels bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedZaakEigenschap'
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakEigenschap'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    delete:
+      operationId: zaakeigenschap_destroy
+      description: Verwijder een ZAAKEIGENSCHAP
+      summary: Verwijder een ZAAKEIGENSCHAP.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '204':
+          description: No content
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+    head:
+      operationId: zaakeigenschap_headers
+      description: Vraag de headers op die je bij een GET request zou krijgen.
+      summary: 'De headers voor een specifiek(e) ZAAKEIGENSCHAP opvragen '
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: If-None-Match
+          schema:
+            type: string
+          description:
+            "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
+            n of meerdere ETag-waardes bevatten van resources die de consumer gecached\
+            \ heeft. Indien de waarde van de ETag van de huidige resource voorkomt in\
+            \ deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie\
+            \ [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)\
+            \ voor meer informatie."
+          examples:
+            OneValue:
+              value: '"79054025255fb1a26e4bc422aef54eb4"'
+              summary: "E\xE9n ETag-waarde"
+            MultipleValues:
+              value: '"79054025255fb1a26e4bc422aef54eb4", "e4d909c290d0fb1ca068ffaddf22cbd0"'
+              summary: Meerdere ETag-waardes
+        - in: path
+          name: zaak_uuid
+          schema:
+            type: string
+            format: uuid
+          description: Unieke resource identifier (UUID4)
+          required: true
+      tags:
+        - zaken
+      responses:
+        '200':
+          headers:
+            ETag:
+              schema:
+                type: string
+              description:
+                De ETag berekend op de response body JSON. Indien twee
+                resources exact dezelfde ETag hebben, dan zijn deze resources identiek
+                aan elkaar. Je kan de ETag gebruiken om caching te implementeren.
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          description: OK
+  /zaken/_zoek:
+    post:
+      operationId: zaak__zoek
+      description:
+        Zoeken/filteren gaat normaal via de `list` operatie, deze is echter
+        niet geschikt voor geo-zoekopdrachten.
+      summary: Voer een (geo)-zoekopdracht uit op ZAAKen.
+      parameters:
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: query
+          name: page
+          schema:
+            type: integer
+          description: Een pagina binnen de gepagineerde set resultaten.
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - zaken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZaakZoek'
+      security:
+        - JWT-Claims:
+            - zaken.lezen
+      responses:
+        '200':
+          headers:
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedZaakList'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+components:
+  responses:
+    '400':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidatieFout'
+      description: Bad request
+    '401':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Unauthorized
+    '403':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Forbidden
+    '404':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Not found
+    '406':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Not acceptable
+    '409':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Conflict
+    '410':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Gone
+    '412':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Precondition failed
+    '415':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Unsupported media type
+    '429':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Too many requests
+    '500':
+      headers:
+        API-version:
+          schema:
+            type: string
+          description:
+            'Geeft een specifieke API-versie aan in de context van een
+            specifieke aanroep. Voorbeeld: 1.2.1.'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Fout'
+      description: Internal server error
+  schemas:
+    AardRelatieEnum:
+      enum:
+        - vervolg
+        - onderwerp
+        - bijdrage
+      type: string
+    AardRelatieWeergaveEnum:
+      enum:
+        - 'Hoort bij, omgekeerd: kent'
+        - 'Legt vast, omgekeerd: kan vastgelegd zijn als'
+      type: string
+    ArchiefnominatieEnum:
+      enum:
+        - blijvend_bewaren
+        - vernietigen
+      type: string
+    ArchiefstatusEnum:
+      enum:
+        - nog_te_archiveren
+        - gearchiveerd
+        - gearchiveerd_procestermijn_onbekend
+        - overgedragen
+      type: string
+    AuditTrail:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          description: Unieke identificatie van de audit regel.
+          title: uuid
+        bron:
+          allOf:
+            - $ref: '#/components/schemas/BronEnum'
+          description:
+            'De naam van het component waar de wijziging in is gedaan.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `ac` - Autorisaties API
+
+            * `nrc` - Notificaties API
+
+            * `zrc` - Zaken API
+
+            * `ztc` - Catalogi API
+
+            * `drc` - Documenten API
+
+            * `brc` - Besluiten API
+
+            * `cmc` - Contactmomenten API
+
+            * `kc` - Klanten API
+
+            * `vrc` - Verzoeken API'
+          title: bron
+        applicatieId:
+          type: string
+          description: Unieke identificatie van de applicatie, binnen de organisatie.
+          title: applicatie id
+          maxLength: 100
+        applicatieWeergave:
+          type: string
+          description: Vriendelijke naam van de applicatie.
+          title: applicatie weergave
+          maxLength: 200
+        gebruikersId:
+          type: string
+          description:
+            Unieke identificatie van de gebruiker die binnen de organisatie
+            herleid kan worden naar een persoon.
+          title: gebruikers id
+          maxLength: 255
+        gebruikersWeergave:
+          type: string
+          description: Vriendelijke naam van de gebruiker.
+          title: gebruikers weergave
+          maxLength: 255
+        actie:
+          type: string
+          description: 'De uitgevoerde handeling.
+
+
+            De bekende waardes voor dit veld zijn hieronder aangegeven,                         maar
+            andere waardes zijn ook toegestaan
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `create` - Object aangemaakt
+
+            * `list` - Lijst van objecten opgehaald
+
+            * `retrieve` - Object opgehaald
+
+            * `destroy` - Object verwijderd
+
+            * `update` - Object bijgewerkt
+
+            * `partial_update` - Object deels bijgewerkt'
+          title: actie
+          maxLength: 50
+        actieWeergave:
+          type: string
+          description: Vriendelijke naam van de actie.
+          title: actie weergave
+          maxLength: 200
+        resultaat:
+          type: integer
+          maximum: 599
+          minimum: 100
+          description: HTTP status code van de API response van de uitgevoerde handeling.
+          title: resultaat
+        hoofdObject:
+          type: string
+          format: uri
+          description: De URL naar het hoofdobject van een component.
+          title: hoofd object
+          maxLength: 1000
+        resource:
+          type: string
+          description: Het type resource waarop de actie gebeurde.
+          title: resource
+          maxLength: 50
+        resourceUrl:
+          type: string
+          format: uri
+          description: De URL naar het object.
+          title: resource url
+          maxLength: 1000
+        toelichting:
+          type: string
+          description: Toelichting waarom de handeling is uitgevoerd.
+          title: toelichting
+        resourceWeergave:
+          type: string
+          description: Vriendelijke identificatie van het object.
+          title: resource weergave
+          maxLength: 200
+        aanmaakdatum:
+          type: string
+          format: date-time
+          readOnly: true
+          description: De datum waarop de handeling is gedaan.
+          title: aanmaakdatum
+        wijzigingen:
+          allOf:
+            - $ref: '#/components/schemas/Wijzigingen'
+          title: wijzigingen
+      required:
+        - aanmaakdatum
+        - actie
+        - bron
+        - hoofdObject
+        - resource
+        - resourceUrl
+        - resourceWeergave
+        - resultaat
+        - wijzigingen
+    BetalingsindicatieEnum:
+      enum:
+        - nvt
+        - nog_niet
+        - gedeeltelijk
+        - geheel
+      type: string
+    BetrokkeneTypeEnum:
+      enum:
+        - natuurlijk_persoon
+        - niet_natuurlijk_persoon
+        - vestiging
+        - organisatorische_eenheid
+        - medewerker
+      type: string
+    BlankEnum:
+      enum:
+        - ''
+    BronEnum:
+      enum:
+        - ac
+        - nrc
+        - zrc
+        - ztc
+        - drc
+        - brc
+        - cmc
+        - kc
+        - vrc
+      type: string
+    ContactPersoonRol:
+      type: object
+      description:
+        De gegevens van de persoon die anderen desgevraagd in contact brengt
+        met medewerkers van de BETROKKENE, een NIET-NATUURLIJK PERSOON of VESTIGING
+        zijnde, of met BETROKKENE zelf, een NATUURLIJK PERSOON zijnde , vanuit het
+        belang van BETROKKENE in haar ROL bij een ZAAK.
+      properties:
+        emailadres:
+          type: string
+          format: email
+          title: Email
+          description:
+            Elektronich postadres waaronder de contactpersoon in de regel
+            bereikbaar is.
+          maxLength: 254
+        functie:
+          type: string
+          description:
+            'De aanduiding van de taken, rechten en plichten die de contactpersoon
+            heeft binnen de organisatie van BETROKKENE. '
+          title: functie
+          maxLength: 50
+        telefoonnummer:
+          type: string
+          description:
+            Telefoonnummer waaronder de contactpersoon in de regel bereikbaar
+            is.
+          title: telefoonnummer
+          maxLength: 20
+        naam:
+          type: string
+          description: De opgemaakte naam van de contactpersoon namens de BETROKKENE.
+          title: naam
+          maxLength: 40
+      required:
+        - naam
+      nullable: true
+    FieldValidationError:
+      type: object
+      description: Formaat van validatiefouten.
+      properties:
+        name:
+          type: string
+          description: Naam van het veld met ongeldige gegevens
+          title: name
+        code:
+          type: string
+          description: Systeemcode die het type fout aangeeft
+          title: code
+        reason:
+          type: string
+          description: Uitleg wat er precies fout is met de gegevens
+          title: reason
+      required:
+        - code
+        - name
+        - reason
+    Fout:
+      type: object
+      description: Formaat van HTTP 4xx en 5xx fouten.
+      properties:
+        type:
+          type: string
+          description: URI referentie naar het type fout, bedoeld voor developers
+          title: type
+        code:
+          type: string
+          description: Systeemcode die het type fout aangeeft
+          title: code
+        title:
+          type: string
+          description: Generieke titel voor het type fout
+          title: title
+        status:
+          type: integer
+          description: De HTTP status code
+          title: status
+        detail:
+          type: string
+          description: Extra informatie bij de fout, indien beschikbaar
+          title: detail
+        instance:
+          type: string
+          description:
+            URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          title: instance
+      required:
+        - code
+        - detail
+        - instance
+        - status
+        - title
+    GeoJSONGeometry:
+      title: GeoJSONGeometry
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/Point'
+        - $ref: '#/components/schemas/MultiPoint'
+        - $ref: '#/components/schemas/LineString'
+        - $ref: '#/components/schemas/MultiLineString'
+        - $ref: '#/components/schemas/Polygon'
+        - $ref: '#/components/schemas/MultiPolygon'
+        - $ref: '#/components/schemas/GeometryCollection'
+      discriminator:
+        propertyName: type
+    GeoWithin:
+      type: object
+      properties:
+        within:
+          allOf:
+            - $ref: '#/components/schemas/GeoJSONGeometry'
+          title: within
+    Geometry:
+      title: Geometry
+      description: GeoJSON geometry
+      type: object
+      required:
+        - type
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/GeometryTypeEnum'
+          description: The geometry type
+    GeometryCollection:
+      title: Geometry collection
+      description: GeoJSON multi-polygon geometry
+      type: object
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1.8
+      allOf:
+        - $ref: '#/components/schemas/Geometry'
+        - type: object
+          required:
+            - geometries
+          properties:
+            geometries:
+              type: array
+              items:
+                $ref: '#/components/schemas/Geometry'
+    GeometryTypeEnum:
+      type: string
+      enum:
+        - Point
+        - MultiPoint
+        - LineString
+        - MultiLineString
+        - Polygon
+        - MultiPolygon
+        - Feature
+        - FeatureCollection
+        - GeometryCollection
+    GeslachtsaanduidingEnum:
+      enum:
+        - m
+        - v
+        - o
+      type: string
+    IndicatieMachtigingEnum:
+      enum:
+        - gemachtigde
+        - machtiginggever
+      type: string
+    InnRechtsvormEnum:
+      enum:
+        - besloten_vennootschap
+        - cooperatie_europees_economische_samenwerking
+        - europese_cooperatieve_venootschap
+        - europese_naamloze_vennootschap
+        - kerkelijke_organisatie
+        - naamloze_vennootschap
+        - onderlinge_waarborg_maatschappij
+        - overig_privaatrechtelijke_rechtspersoon
+        - stichting
+        - vereniging
+        - vereniging_van_eigenaars
+        - publiekrechtelijke_rechtspersoon
+        - vennootschap_onder_firma
+        - maatschap
+        - rederij
+        - commanditaire_vennootschap
+        - kapitaalvennootschap_binnen_eer
+        - overige_buitenlandse_rechtspersoon_vennootschap
+        - kapitaalvennootschap_buiten_eer
+      type: string
+    KlantContact:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        identificatie:
+          type: string
+          description: De unieke aanduiding van een KLANTCONTACT
+          title: identificatie
+          maxLength: 14
+        datumtijd:
+          type: string
+          format: date-time
+          description: De datum en het tijdstip waarop het KLANTCONTACT begint
+          title: datumtijd
+        kanaal:
+          type: string
+          description: Het communicatiekanaal waarlangs het KLANTCONTACT gevoerd wordt
+          title: kanaal
+          maxLength: 20
+        onderwerp:
+          type: string
+          description: Het onderwerp waarover contact is geweest met de klant.
+          title: onderwerp
+          maxLength: 200
+        toelichting:
+          type: string
+          description: Een toelichting die inhoudelijk het contact met de klant beschrijft.
+          title: toelichting
+          maxLength: 1000
+      required:
+        - datumtijd
+        - url
+        - uuid
+        - zaak
+    LineString:
+      title: Line-string
+      description: GeoJSON line-string geometry
+      type: object
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1.4
+      allOf:
+        - $ref: '#/components/schemas/Geometry'
+        - type: object
+          required:
+            - coordinates
+          properties:
+            coordinates:
+              type: array
+              items:
+                $ref: '#/components/schemas/Point2D'
+              minItems: 2
+    MultiLineString:
+      title: Multi-line string
+      description: GeoJSON multi-line-string geometry
+      type: object
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1.5
+      allOf:
+        - $ref: '#/components/schemas/Geometry'
+        - type: object
+          required:
+            - coordinates
+          properties:
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Point2D'
+    MultiPoint:
+      title: MultiPoint
+      description: GeoJSON multi-point geometry
+      type: object
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1.3
+      allOf:
+        - $ref: '#/components/schemas/Geometry'
+        - type: object
+          required:
+            - coordinates
+          properties:
+            coordinates:
+              type: array
+              items:
+                $ref: '#/components/schemas/Point2D'
+    MultiPolygon:
+      title: Multi-polygon
+      description: GeoJSON multi-polygon geometry
+      type: object
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1.7
+      allOf:
+        - $ref: '#/components/schemas/Geometry'
+        - type: object
+          required:
+            - coordinates
+          properties:
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Point2D'
+    NullEnum:
+      enum:
+        - null
+    ObjectAdres:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        wplWoonplaatsNaam:
+          type: string
+          title: wpl woonplaats naam
+          maxLength: 80
+        gorOpenbareRuimteNaam:
+          type: string
+          description:
+            Een door het bevoegde gemeentelijke orgaan aan een OPENBARE
+            RUIMTE toegekende benaming
+          title: gor openbare ruimte naam
+          maxLength: 80
+        huisnummer:
+          type: integer
+          maximum: 99999
+          minimum: 0
+          title: huisnummer
+        huisletter:
+          type: string
+          title: huisletter
+          maxLength: 1
+        huisnummertoevoeging:
+          type: string
+          title: huisnummertoevoeging
+          maxLength: 4
+        postcode:
+          type: string
+          title: postcode
+          maxLength: 7
+      required:
+        - gorOpenbareRuimteNaam
+        - huisnummer
+        - identificatie
+        - wplWoonplaatsNaam
+    ObjectBuurt:
+      type: object
+      properties:
+        buurtCode:
+          type: string
+          description: De code behorende bij de naam van de buurt
+          title: buurt code
+          maxLength: 2
+        buurtNaam:
+          type: string
+          description: De naam van de buurt, zoals die door het CBS wordt gebruikt.
+          title: buurt naam
+          maxLength: 40
+        gemGemeenteCode:
+          type: string
+          description:
+            Een numerieke aanduiding waarmee een Nederlandse gemeente uniek
+            wordt aangeduid
+          title: gem gemeente code
+          maxLength: 4
+        wykWijkCode:
+          type: string
+          description: De code behorende bij de naam van de wijk
+          title: wyk wijk code
+          maxLength: 2
+      required:
+        - buurtCode
+        - buurtNaam
+        - gemGemeenteCode
+        - wykWijkCode
+    ObjectGemeente:
+      type: object
+      properties:
+        gemeenteNaam:
+          type: string
+          description: "De offici\xEBle door de gemeente vastgestelde gemeentenaam."
+          title: gemeente naam
+          maxLength: 80
+        gemeenteCode:
+          type: string
+          description:
+            Een numerieke aanduiding waarmee een Nederlandse gemeente uniek
+            wordt aangeduid
+          title: gemeente code
+          maxLength: 4
+      required:
+        - gemeenteCode
+        - gemeenteNaam
+    ObjectGemeentelijkeOpenbareRuimte:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        openbareRuimteNaam:
+          type: string
+          description:
+            Een door het bevoegde gemeentelijke orgaan aan een OPENBARE
+            RUIMTE toegekende benaming
+          title: openbare ruimte naam
+          maxLength: 80
+      required:
+        - identificatie
+        - openbareRuimteNaam
+    ObjectHuishouden:
+      type: object
+      properties:
+        nummer:
+          type: string
+          description:
+            Uniek identificerend administratienummer van een huishouden
+            zoals toegekend door de gemeente waarin het huishouden woonachtig is.
+          title: nummer
+          maxLength: 12
+        isGehuisvestIn:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTerreinGebouwdObject'
+          nullable: true
+          title: isGehuisvestIn
+      required:
+        - nummer
+    ObjectInrichtingselement:
+      type: object
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ObjectInrichtingselementTypeEnum'
+          description: 'Specificatie van de aard van het inrichtingselement.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `bak` - Bak
+
+            * `bord` - Bord
+
+            * `installatie` - Installatie
+
+            * `kast` - Kast
+
+            * `mast` - Mast
+
+            * `paal` - Paal
+
+            * `sensor` - Sensor
+
+            * `straatmeubilair` - Straatmeubilair
+
+            * `waterinrichtingselement` - Waterinrichtingselement
+
+            * `weginrichtingselement` - Weginrichtingselement'
+          title: type
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        naam:
+          type: string
+          description: De benaming van het OBJECT
+          title: naam
+          maxLength: 500
+      required:
+        - identificatie
+        - type
+    ObjectInrichtingselementTypeEnum:
+      enum:
+        - bak
+        - bord
+        - installatie
+        - kast
+        - mast
+        - paal
+        - sensor
+        - straatmeubilair
+        - waterinrichtingselement
+        - weginrichtingselement
+      type: string
+    ObjectKadastraleOnroerendeZaak:
+      type: object
+      properties:
+        kadastraleIdentificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: kadastrale identificatie
+          maxLength: 100
+        kadastraleAanduiding:
+          type: string
+          description:
+            De typering van de kadastrale aanduiding van een onroerende
+            zaak conform Kadaster
+          title: kadastrale aanduiding
+          maxLength: 1000
+      required:
+        - kadastraleAanduiding
+        - kadastraleIdentificatie
+    ObjectKunstwerkdeel:
+      type: object
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ObjectKunstwerkdeelTypeEnum'
+          description:
+            'Specificatie van het soort Kunstwerk waartoe het kunstwerkdeel
+            behoort.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `keermuur` - Keermuur
+
+            * `overkluizing` - Overkluizing
+
+            * `duiker` - Duiker
+
+            * `faunavoorziening` - Faunavoorziening
+
+            * `vispassage` - Vispassage
+
+            * `bodemval` - Bodemval
+
+            * `coupure` - Coupure
+
+            * `ponton` - Ponton
+
+            * `voorde` - Voorde
+
+            * `hoogspanningsmast` - Hoogspanningsmast
+
+            * `gemaal` - Gemaal
+
+            * `perron` - Perron
+
+            * `sluis` - Sluis
+
+            * `strekdam` - Strekdam
+
+            * `steiger` - Steiger
+
+            * `stuw` - Stuw'
+          title: type
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        naam:
+          type: string
+          title: naam
+          maxLength: 80
+      required:
+        - identificatie
+        - naam
+        - type
+    ObjectKunstwerkdeelTypeEnum:
+      enum:
+        - keermuur
+        - overkluizing
+        - duiker
+        - faunavoorziening
+        - vispassage
+        - bodemval
+        - coupure
+        - ponton
+        - voorde
+        - hoogspanningsmast
+        - gemaal
+        - perron
+        - sluis
+        - strekdam
+        - steiger
+        - stuw
+      type: string
+    ObjectMaatschappelijkeActiviteit:
+      type: object
+      properties:
+        kvkNummer:
+          type: string
+          description:
+            Landelijk uniek identificerend administratienummer van een
+            MAATSCHAPPELIJKE ACTIVITEIT zoals toegewezen door de Kamer van Koophandel
+            (KvK).
+          title: kvk nummer
+          maxLength: 8
+        handelsnaam:
+          type: string
+          description: De naam waaronder de onderneming handelt.
+          title: handelsnaam
+          maxLength: 200
+      required:
+        - handelsnaam
+        - kvkNummer
+    ObjectOpenbareRuimte:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        wplWoonplaatsNaam:
+          type: string
+          title: wpl woonplaats naam
+          maxLength: 80
+        gorOpenbareRuimteNaam:
+          type: string
+          description:
+            Een door het bevoegde gemeentelijke orgaan aan een OPENBARE
+            RUIMTE toegekende benaming
+          title: gor openbare ruimte naam
+          maxLength: 80
+      required:
+        - gorOpenbareRuimteNaam
+        - identificatie
+        - wplWoonplaatsNaam
+    ObjectOverige:
+      type: object
+      properties:
+        overigeData:
+          type: object
+          additionalProperties: {}
+          title: overige data
+      required:
+        - overigeData
+    ObjectPand:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+      required:
+        - identificatie
+    ObjectSpoorbaandeel:
+      type: object
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/ObjectSpoorbaandeelTypeEnum'
+          description: 'Specificatie van het soort Spoorbaan
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `breedspoor` - breedspoor
+
+            * `normaalspoor` - normaalspoor
+
+            * `smalspoor` - smalspoor
+
+            * `spoorbaan` - spoorbaan'
+          title: type
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        naam:
+          type: string
+          description: De benaming van het OBJECT
+          title: naam
+          maxLength: 500
+      required:
+        - identificatie
+        - type
+    ObjectSpoorbaandeelTypeEnum:
+      enum:
+        - breedspoor
+        - normaalspoor
+        - smalspoor
+        - spoorbaan
+      type: string
+    ObjectTerreinGebouwdObject:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        adresAanduidingGrp:
+          allOf:
+            - $ref: '#/components/schemas/TerreinGebouwdObjectAdres'
+          nullable: true
+          title: adresAanduidingGrp
+      required:
+        - identificatie
+    ObjectTerreindeel:
+      type: object
+      properties:
+        type:
+          type: string
+          title: type
+          maxLength: 40
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        naam:
+          type: string
+          description: De benaming van het OBJECT
+          title: naam
+          maxLength: 500
+      required:
+        - identificatie
+        - type
+    ObjectTypeEnum:
+      enum:
+        - adres
+        - besluit
+        - buurt
+        - enkelvoudig_document
+        - gemeente
+        - gemeentelijke_openbare_ruimte
+        - huishouden
+        - inrichtingselement
+        - kadastrale_onroerende_zaak
+        - kunstwerkdeel
+        - maatschappelijke_activiteit
+        - medewerker
+        - natuurlijk_persoon
+        - niet_natuurlijk_persoon
+        - openbare_ruimte
+        - organisatorische_eenheid
+        - pand
+        - spoorbaandeel
+        - status
+        - terreindeel
+        - terrein_gebouwd_object
+        - vestiging
+        - waterdeel
+        - wegdeel
+        - wijk
+        - woonplaats
+        - woz_deelobject
+        - woz_object
+        - woz_waarde
+        - zakelijk_recht
+        - overige
+      type: string
+    ObjectTypeOverigeDefinitie:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          title: Objecttype-URL
+          description:
+            URL-referentie naar de objecttype resource in een API. Deze
+            resource moet de [JSON-schema](https://json-schema.org/)-definitie van
+            het objecttype bevatten.
+          maxLength: 1000
+        schema:
+          type: string
+          title: schema-pad
+          description:
+            'Een geldige [jq](http://stedolan.github.io/jq/) expressie.
+            Dit wordt gecombineerd met de resource uit het `url`-attribuut om het
+            schema van het objecttype uit te lezen. Bijvoorbeeld: `.jsonSchema`.'
+          maxLength: 100
+        objectData:
+          type: string
+          title: objectgegevens-pad
+          description:
+            'Een geldige [jq](http://stedolan.github.io/jq/) expressie.
+            Dit wordt gecombineerd met de JSON data uit de OBJECT url om de objectgegevens
+            uit te lezen en de vorm van de gegevens tegen het schema te valideren.
+            Bijvoorbeeld: `.record.data`.'
+          maxLength: 100
+      required:
+        - objectData
+        - schema
+        - url
+    ObjectWaterdeel:
+      type: object
+      properties:
+        typeWaterdeel:
+          allOf:
+            - $ref: '#/components/schemas/TypeWaterdeelEnum'
+          description: 'Specificatie van het soort water
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `zee` - Zee
+
+            * `waterloop` - Waterloop
+
+            * `watervlakte` - Watervlakte
+
+            * `greppel_droge_sloot` - Greppel, droge sloot'
+          title: type waterdeel
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        naam:
+          type: string
+          description: De benaming van het OBJECT
+          title: naam
+          maxLength: 500
+      required:
+        - identificatie
+        - typeWaterdeel
+    ObjectWegdeel:
+      type: object
+      properties:
+        type:
+          type: string
+          title: type
+          maxLength: 100
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        naam:
+          type: string
+          description: De benaming van het OBJECT
+          title: naam
+          maxLength: 500
+      required:
+        - identificatie
+        - type
+    ObjectWijk:
+      type: object
+      properties:
+        wijkCode:
+          type: string
+          description: De code behorende bij de naam van de wijk.
+          title: wijk code
+          maxLength: 2
+        wijkNaam:
+          type: string
+          description: De naam van de wijk, zoals die door het CBS wordt gebruikt.
+          title: wijk naam
+          maxLength: 40
+        gemGemeenteCode:
+          type: string
+          description:
+            Een numerieke aanduiding waarmee een Nederlandse gemeente uniek
+            wordt aangeduid
+          title: gem gemeente code
+          maxLength: 4
+      required:
+        - gemGemeenteCode
+        - wijkCode
+        - wijkNaam
+    ObjectWoonplaats:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        woonplaatsNaam:
+          type: string
+          description:
+            De door het bevoegde gemeentelijke orgaan aan een WOONPLAATS
+            toegekende benaming.
+          title: woonplaats naam
+          maxLength: 80
+      required:
+        - identificatie
+        - woonplaatsNaam
+    ObjectWozDeelobject:
+      type: object
+      properties:
+        nummerWozDeelObject:
+          type: string
+          description: Uniek identificatienummer voor het deelobject binnen een WOZ-object.
+          title: nummer woz deel object
+          maxLength: 6
+        isOnderdeelVan:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWozObject'
+          title: isOnderdeelVan
+      required:
+        - nummerWozDeelObject
+    ObjectWozObject:
+      type: object
+      properties:
+        wozObjectNummer:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: woz object nummer
+          maxLength: 100
+        aanduidingWozObject:
+          allOf:
+            - $ref: '#/components/schemas/WozObjectAdres'
+          nullable: true
+          title: aanduidingWozObject
+      required:
+        - wozObjectNummer
+    ObjectWozWaarde:
+      type: object
+      properties:
+        waardepeildatum:
+          type: string
+          description: De datum waarnaar de waarde van het WOZ-object wordt bepaald.
+          title: waardepeildatum
+          maxLength: 9
+        isVoor:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWozObject'
+          title: isVoor
+      required:
+        - waardepeildatum
+    ObjectZakelijkRecht:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        avgAard:
+          type: string
+          description: aanduiding voor de aard van het recht
+          title: avg aard
+          maxLength: 1000
+        heeftBetrekkingOp:
+          allOf:
+            - $ref: '#/components/schemas/ObjectKadastraleOnroerendeZaak'
+          title: heeftBetrekkingOp
+        heeftAlsGerechtigde:
+          allOf:
+            - $ref: '#/components/schemas/ZakelijkRechtHeeftAlsGerechtigde'
+          title: heeftAlsGerechtigde
+      required:
+        - avgAard
+        - identificatie
+    Opschorting:
+      type: object
+      description:
+        Gegevens omtrent het tijdelijk opschorten van de behandeling van
+        de ZAAK
+      properties:
+        indicatie:
+          type: boolean
+          description: Aanduiding of de behandeling van de ZAAK tijdelijk is opgeschort.
+          title: indicatie opschorting
+        reden:
+          type: string
+          description:
+            Omschrijving van de reden voor het opschorten van de behandeling
+            van de zaak.
+          title: reden opschorting
+          maxLength: 200
+      required:
+        - indicatie
+        - reden
+      nullable: true
+    PaginatedKlantContactList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/KlantContact'
+    PaginatedResultaatList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Resultaat'
+    PaginatedRolList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rol'
+    PaginatedStatusList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Status'
+    PaginatedZaakList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ZaakExpanded'
+    PaginatedZaakObjectList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ZaakObject'
+    PatchedResultaat:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        resultaattype:
+          type: string
+          format: uri
+          description: URL-referentie naar het RESULTAATTYPE (in de Catalogi API).
+          title: resultaattype
+          maxLength: 1000
+        toelichting:
+          type: string
+          description: Een toelichting op wat het resultaat van de zaak inhoudt.
+          title: toelichting
+          maxLength: 1000
+    PatchedZaak:
+      type: object
+      description: 'Set gegevensgroepdata from validated nested data.
+
+
+        Usage: include the mixin on the ModelSerializer that has gegevensgroepen.'
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        identificatie:
+          type: string
+          description:
+            De unieke identificatie van de ZAAK binnen de organisatie die
+            verantwoordelijk is voor de behandeling van de ZAAK.
+          title: identificatie
+          maxLength: 40
+        bronorganisatie:
+          type: string
+          description:
+            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie
+            die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers
+            en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
+          title: bronorganisatie
+          maxLength: 9
+        omschrijving:
+          type: string
+          description: Een korte omschrijving van de zaak.
+          title: omschrijving
+          maxLength: 80
+        toelichting:
+          type: string
+          description: Een toelichting op de zaak.
+          title: toelichting
+          maxLength: 1000
+        zaaktype:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar het ZAAKTYPE (in de Catalogi API) in de
+            CATALOGUS waar deze voorkomt
+          title: zaaktype
+          maxLength: 1000
+        registratiedatum:
+          type: string
+          format: date
+          description:
+            De datum waarop de zaakbehandelende organisatie de ZAAK heeft
+            geregistreerd. Indien deze niet opgegeven wordt, wordt de datum van vandaag
+            gebruikt.
+          title: registratiedatum
+        verantwoordelijkeOrganisatie:
+          type: string
+          description:
+            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie
+            die eindverantwoordelijk is voor de behandeling van de zaak. Dit moet
+            een geldig RSIN zijn van 9 nummers en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
+          title: verantwoordelijke organisatie
+          maxLength: 9
+        startdatum:
+          type: string
+          format: date
+          description: De datum waarop met de uitvoering van de zaak is gestart
+          title: startdatum
+        einddatum:
+          type: string
+          format: date
+          readOnly: true
+          nullable: true
+          description: De datum waarop de uitvoering van de zaak afgerond is.
+          title: einddatum
+        einddatumGepland:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De datum waarop volgens de planning verwacht wordt dat de zaak
+            afgerond wordt.
+          title: einddatum gepland
+        uiterlijkeEinddatumAfdoening:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De laatste datum waarop volgens wet- en regelgeving de zaak
+            afgerond dient te zijn.
+          title: uiterlijke einddatum afdoening
+        publicatiedatum:
+          type: string
+          format: date
+          nullable: true
+          description: Datum waarop (het starten van) de zaak gepubliceerd is of wordt.
+          title: publicatiedatum
+        communicatiekanaal:
+          type: string
+          format: uri
+          description:
+            Het medium waarlangs de aanleiding om een zaak te starten is
+            ontvangen. URL naar een communicatiekanaal in de VNG-Referentielijst van
+            communicatiekanalen.
+          title: communicatiekanaal
+          maxLength: 1000
+        productenOfDiensten:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: URL naar product/dienst
+            maxLength: 1000
+          description:
+            De producten en/of diensten die door de zaak worden voortgebracht.
+            Dit zijn URLs naar de resources zoals die door de producten- en dienstencatalogus-API
+            wordt ontsloten. De producten/diensten moeten bij het zaaktype vermeld
+            zijn.
+          title: producten of diensten
+        vertrouwelijkheidaanduiding:
+          allOf:
+            - $ref: '#/components/schemas/VertrouwelijkheidaanduidingEnum'
+          title: Vertrouwlijkheidaanduiding
+          description:
+            Aanduiding van de mate waarin het zaakdossier van de ZAAK voor
+            de openbaarheid bestemd is. Optioneel - indien geen waarde gekozen wordt,
+            dan wordt de waarde van het ZAAKTYPE overgenomen. Dit betekent dat de
+            API _altijd_ een waarde teruggeeft.
+        betalingsindicatie:
+          description:
+            'Indicatie of de, met behandeling van de zaak gemoeide, kosten
+            betaald zijn door de desbetreffende betrokkene.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `nvt` - Er is geen sprake van te betalen, met de zaak gemoeide, kosten.
+
+            * `nog_niet` - De met de zaak gemoeide kosten zijn (nog) niet betaald.
+
+            * `gedeeltelijk` - De met de zaak gemoeide kosten zijn gedeeltelijk betaald.
+
+            * `geheel` - De met de zaak gemoeide kosten zijn geheel betaald.'
+          title: betalingsindicatie
+          oneOf:
+            - $ref: '#/components/schemas/BetalingsindicatieEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        betalingsindicatieWeergave:
+          type: string
+          readOnly: true
+          description: Uitleg bij `betalingsindicatie`.
+          title: betalingsindicatieWeergave
+        laatsteBetaaldatum:
+          type: string
+          format: date-time
+          nullable: true
+          description:
+            De datum waarop de meest recente betaling is verwerkt van kosten
+            die gemoeid zijn met behandeling van de zaak.
+          title: laatste betaaldatum
+        zaakgeometrie:
+          allOf:
+            - $ref: '#/components/schemas/GeoJSONGeometry'
+          nullable: true
+          description: Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON.
+          title: zaakgeometrie
+        verlenging:
+          allOf:
+            - $ref: '#/components/schemas/Verlenging'
+          nullable: true
+          description:
+            Gegevens omtrent het verlengen van de doorlooptijd van de behandeling
+            van de ZAAK
+          title: verlenging
+        opschorting:
+          allOf:
+            - $ref: '#/components/schemas/Opschorting'
+          nullable: true
+          description:
+            Gegevens omtrent het tijdelijk opschorten van de behandeling
+            van de ZAAK
+          title: opschorting
+        selectielijstklasse:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar de categorie in de gehanteerde 'Selectielijst
+            Archiefbescheiden' die, gezien het zaaktype en het resultaattype van de
+            zaak, bepalend is voor het archiefregime van de zaak.
+          title: selectielijstklasse
+          maxLength: 1000
+        hoofdzaak:
+          type: string
+          format: uri
+          nullable: true
+          title: Is deelzaak van
+          description:
+            "URL-referentie naar de ZAAK, waarom verzocht is door de initiator\
+            \ daarvan, die behandeld wordt in twee of meer separate ZAAKen waarvan\
+            \ de onderhavige ZAAK er \xE9\xE9n is."
+          minLength: 1
+          maxLength: 1000
+        deelzaken:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          description: URL-referenties naar deel ZAAKen.
+          title: is deelzaak van
+          uniqueItems: true
+        relevanteAndereZaken:
+          type: array
+          items:
+            $ref: '#/components/schemas/RelevanteZaak'
+          description: Een lijst van relevante andere zaken.
+          title: zaak
+        eigenschappen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        rollen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        status:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description: Indien geen status bekend is, dan is de waarde 'null'
+          title: status
+        zaakinformatieobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        zaakobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        kenmerken:
+          type: array
+          items:
+            $ref: '#/components/schemas/ZaakKenmerk'
+          description:
+            Lijst van kenmerken. Merk op dat refereren naar gerelateerde
+            objecten beter kan via `ZaakObject`.
+          title: zaak
+        archiefnominatie:
+          nullable: true
+          description:
+            'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum
+            overgedragen worden naar een archiefbewaarplaats.
+
+            * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd
+            worden.'
+          title: archiefnominatie
+          oneOf:
+            - $ref: '#/components/schemas/ArchiefnominatieEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+            - $ref: '#/components/schemas/NullEnum'
+        archiefstatus:
+          allOf:
+            - $ref: '#/components/schemas/ArchiefstatusEnum'
+          description:
+            'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `nog_te_archiveren` - De zaak cq. het zaakdossier is nog niet als geheel
+            gearchiveerd.
+
+            * `gearchiveerd` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar
+            bewaarbaar gemaakt.
+
+            * `gearchiveerd_procestermijn_onbekend` - De zaak cq. het zaakdossier
+            is als geheel niet-wijzigbaar bewaarbaar gemaakt maar de vernietigingsdatum
+            kan nog niet bepaald worden.
+
+            * `overgedragen` - De zaak cq. het zaakdossier is overgebracht naar een
+            archiefbewaarplaats.'
+          title: archiefstatus
+        archiefactiedatum:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De datum waarop het gearchiveerde zaakdossier vernietigd moet
+            worden dan wel overgebracht moet worden naar een archiefbewaarplaats.
+            Wordt automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT
+            aan deze ZAAK indien nog leeg.
+          title: archiefactiedatum
+        resultaat:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description:
+            URL-referentie naar het RESULTAAT. Indien geen resultaat bekend
+            is, dan is de waarde 'null'
+          title: resultaat
+        opdrachtgevendeOrganisatie:
+          type: string
+          description:
+            De krachtens publiekrecht ingestelde rechtspersoon dan wel
+            ander niet-natuurlijk persoon waarbinnen het (bestuurs)orgaan zetelt dat
+            opdracht heeft gegeven om taken uit te voeren waaraan de zaak invulling
+            geeft.
+          title: opdrachtgevende organisatie
+          maxLength: 9
+        processobjectaard:
+          type: string
+          nullable: true
+          title: Procesobjectaard
+          description:
+            Omschrijving van het object, subject of gebeurtenis waarop,
+            vanuit archiveringsoptiek, de zaak betrekking heeft.
+          maxLength: 200
+        startdatumBewaartermijn:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De datum die de start markeert van de termijn waarop het zaakdossier
+            vernietigd moet worden.
+          title: startdatum bewaartermijn
+        processobject:
+          allOf:
+            - $ref: '#/components/schemas/Processobject'
+          nullable: true
+          description:
+            Specificatie van de attribuutsoort van het object, subject
+            of gebeurtenis  waarop, vanuit archiveringsoptiek, de zaak betrekking
+            heeft en dat bepalend is voor de start van de archiefactietermijn.
+          title: processobject
+    PatchedZaakEigenschap:
+      type: object
+      description:
+        "A type of `ModelSerializer` that uses hyperlinked relationships
+        with compound keys instead
+
+        of primary key relationships.  Specifically:
+
+
+        * A 'url' field is included instead of the 'id' field.
+
+        * Relationships to other instances are hyperlinks, instead of primary keys.
+
+
+        NOTE: this only works with DRF 3.1.0 and above."
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          title: zaak
+        eigenschap:
+          type: string
+          format: uri
+          description: URL-referentie naar de EIGENSCHAP (in de Catalogi API).
+          title: eigenschap
+          maxLength: 1000
+        naam:
+          type: string
+          readOnly: true
+          description: De naam van de EIGENSCHAP (overgenomen uit de Catalogi API).
+          title: ' naam'
+        waarde:
+          type: string
+          title: waarde
+    PatchedZaakInformatieObject:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        informatieobject:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar het INFORMATIEOBJECT (in de Documenten
+            API), waar ook de relatieinformatie opgevraagd kan worden.
+          title: informatieobject
+          maxLength: 1000
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        aardRelatieWeergave:
+          allOf:
+            - $ref: '#/components/schemas/AardRelatieWeergaveEnum'
+          readOnly: true
+          title: aardRelatieWeergave
+        titel:
+          type: string
+          description:
+            De naam waaronder het INFORMATIEOBJECT binnen het OBJECT bekend
+            is.
+          title: titel
+          maxLength: 200
+        beschrijving:
+          type: string
+          description:
+            Een op het object gerichte beschrijving van de inhoud vanhet
+            INFORMATIEOBJECT.
+          title: beschrijving
+        registratiedatum:
+          type: string
+          format: date-time
+          readOnly: true
+          description:
+            De datum waarop de behandelende organisatie het INFORMATIEOBJECT
+            heeft geregistreerd bij het OBJECT. Geldige waardes zijn datumtijden gelegen
+            op of voor de huidige datum en tijd.
+          title: registratiedatum
+        vernietigingsdatum:
+          type: string
+          format: date-time
+          nullable: true
+          description:
+            De datum waarop het informatieobject uit het zaakdossier verwijderd
+            moet worden.
+          title: vernietigingsdatum
+        status:
+          type: string
+          format: uri
+          nullable: true
+          description:
+            De bij de desbetreffende ZAAK behorende STATUS waarvoor het
+            ZAAK-INFORMATIEOBJECT relevant is (geweest) met het oog op het bereiken
+            van die STATUS en/of de communicatie daarover.
+          title: status
+          minLength: 1
+          maxLength: 1000
+    PatchedZaakObject:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        object:
+          type: string
+          format: uri
+          description: URL-referentie naar de resource die het OBJECT beschrijft.
+          title: object
+          maxLength: 1000
+        zaakobjecttype:
+          type: string
+          format: uri
+          description: URL-referentie naar het ZAAKOBJECTTYPE (in de Catalogi API).
+          title: zaakobjecttype
+          maxLength: 1000
+        objectType:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeEnum'
+          description:
+            'Beschrijft het type OBJECT gerelateerd aan de ZAAK. Als er
+            geen passend type is, dan moet het type worden opgegeven onder `objectTypeOverige`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `adres` - Adres
+
+            * `besluit` - Besluit
+
+            * `buurt` - Buurt
+
+            * `enkelvoudig_document` - Enkelvoudig document
+
+            * `gemeente` - Gemeente
+
+            * `gemeentelijke_openbare_ruimte` - Gemeentelijke openbare ruimte
+
+            * `huishouden` - Huishouden
+
+            * `inrichtingselement` - Inrichtingselement
+
+            * `kadastrale_onroerende_zaak` - Kadastrale onroerende zaak
+
+            * `kunstwerkdeel` - Kunstwerkdeel
+
+            * `maatschappelijke_activiteit` - Maatschappelijke activiteit
+
+            * `medewerker` - Medewerker
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `openbare_ruimte` - Openbare ruimte
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `pand` - Pand
+
+            * `spoorbaandeel` - Spoorbaandeel
+
+            * `status` - Status
+
+            * `terreindeel` - Terreindeel
+
+            * `terrein_gebouwd_object` - Terrein gebouwd object
+
+            * `vestiging` - Vestiging
+
+            * `waterdeel` - Waterdeel
+
+            * `wegdeel` - Wegdeel
+
+            * `wijk` - Wijk
+
+            * `woonplaats` - Woonplaats
+
+            * `woz_deelobject` - Woz deel object
+
+            * `woz_object` - Woz object
+
+            * `woz_waarde` - Woz waarde
+
+            * `zakelijk_recht` - Zakelijk recht
+
+            * `overige` - Overige'
+          title: object type
+        objectTypeOverige:
+          type: string
+          description:
+            Beschrijft het type OBJECT als `objectType` de waarde "overige"
+            heeft.
+          title: object type overige
+          pattern: '[a-z\_]+'
+          maxLength: 100
+        objectTypeOverigeDefinitie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeOverigeDefinitie'
+          nullable: true
+          title: definitie object type overige
+          description:
+            'Verwijzing naar het schema van het type OBJECT als `objectType`
+            de waarde "overige" heeft.
+
+
+            * De URL referentie moet naar een JSON endpoint   wijzen waarin het objecttype
+            gedefinieerd is, inclusief het   [JSON-schema](https://json-schema.org/).
+
+            * Gebruik het `schema` attribuut om te verwijzen naar het schema binnen   de
+            objecttype resource (deze gebruikt het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+            * Gebruik het `objectData` attribuut om te verwijzen naar de gegevens   binnen
+            het OBJECT. Deze gebruikt ook het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+
+            Indien je hier gebruikt van maakt, dan moet je een OBJECT url opgeven
+            en is het gebruik van objectIdentificatie niet mogelijk. De opgegeven
+            OBJECT url wordt gevalideerd tegen het schema van het opgegeven objecttype.'
+        relatieomschrijving:
+          type: string
+          description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
+          title: relatieomschrijving
+          maxLength: 80
+      discriminator:
+        propertyName: objectType
+        mapping:
+          adres: '#/components/schemas/adres_PatchedZaakObject'
+          besluit: '#/components/schemas/besluit_PatchedZaakObject'
+          buurt: '#/components/schemas/buurt_PatchedZaakObject'
+          enkelvoudig_document: '#/components/schemas/enkelvoudig_document_PatchedZaakObject'
+          gemeente: '#/components/schemas/gemeente_PatchedZaakObject'
+          gemeentelijke_openbare_ruimte: '#/components/schemas/gemeentelijke_openbare_ruimte_PatchedZaakObject'
+          huishouden: '#/components/schemas/huishouden_PatchedZaakObject'
+          inrichtingselement: '#/components/schemas/inrichtingselement_PatchedZaakObject'
+          kadastrale_onroerende_zaak: '#/components/schemas/kadastrale_onroerende_zaak_PatchedZaakObject'
+          kunstwerkdeel: '#/components/schemas/kunstwerkdeel_PatchedZaakObject'
+          maatschappelijke_activiteit: '#/components/schemas/maatschappelijke_activiteit_PatchedZaakObject'
+          medewerker: '#/components/schemas/medewerker_PatchedZaakObject'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_PatchedZaakObject'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_PatchedZaakObject'
+          openbare_ruimte: '#/components/schemas/openbare_ruimte_PatchedZaakObject'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_PatchedZaakObject'
+          pand: '#/components/schemas/pand_PatchedZaakObject'
+          spoorbaandeel: '#/components/schemas/spoorbaandeel_PatchedZaakObject'
+          status: '#/components/schemas/status_PatchedZaakObject'
+          terreindeel: '#/components/schemas/terreindeel_PatchedZaakObject'
+          terrein_gebouwd_object: '#/components/schemas/terrein_gebouwd_object_PatchedZaakObject'
+          vestiging: '#/components/schemas/vestiging_PatchedZaakObject'
+          waterdeel: '#/components/schemas/waterdeel_PatchedZaakObject'
+          wegdeel: '#/components/schemas/wegdeel_PatchedZaakObject'
+          wijk: '#/components/schemas/wijk_PatchedZaakObject'
+          woonplaats: '#/components/schemas/woonplaats_PatchedZaakObject'
+          woz_deelobject: '#/components/schemas/woz_deelobject_PatchedZaakObject'
+          woz_object: '#/components/schemas/woz_object_PatchedZaakObject'
+          woz_waarde: '#/components/schemas/woz_waarde_PatchedZaakObject'
+          zakelijk_recht: '#/components/schemas/zakelijk_recht_PatchedZaakObject'
+          overige: '#/components/schemas/overige_PatchedZaakObject'
+    Point:
+      title: Point
+      description: GeoJSON point geometry
+      type: object
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1.2
+      allOf:
+        - $ref: '#/components/schemas/Geometry'
+        - type: object
+          required:
+            - coordinates
+          properties:
+            coordinates:
+              $ref: '#/components/schemas/Point2D'
+    Point2D:
+      title: Point2D
+      type: array
+      items:
+        type: number
+      maxItems: 2
+      minItems: 2
+    Polygon:
+      title: Polygon
+      description: GeoJSON polygon geometry
+      type: object
+      externalDocs:
+        url: https://tools.ietf.org/html/rfc7946#section-3.1.6
+      allOf:
+        - $ref: '#/components/schemas/Geometry'
+        - type: object
+          required:
+            - coordinates
+          properties:
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Point2D'
+    Processobject:
+      type: object
+      description:
+        Specificatie van de attribuutsoort van het object, subject of gebeurtenis  waarop,
+        vanuit archiveringsoptiek, de zaak betrekking heeft en dat bepalend is voor
+        de start van de archiefactietermijn.
+      properties:
+        datumkenmerk:
+          type: string
+          description:
+            De naam van de attribuutsoort van het procesobject dat bepalend
+            is voor het einde van de procestermijn.
+          title: datumkenmerk
+          maxLength: 250
+        identificatie:
+          type: string
+          description: De unieke aanduiding van het procesobject.
+          title: identificatie
+          maxLength: 250
+        objecttype:
+          type: string
+          description: Het soort object dat het procesobject representeert.
+          title: objecttype
+          maxLength: 250
+        registratie:
+          type: string
+          description:
+            De naam van de registratie waarvan het procesobject deel uit
+            maakt.
+          title: registratie
+          maxLength: 250
+      required:
+        - datumkenmerk
+        - identificatie
+        - objecttype
+        - registratie
+      nullable: true
+    RelevanteZaak:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          title: URL-referentie naar de ZAAK.
+          maxLength: 1000
+        aardRelatie:
+          allOf:
+            - $ref: '#/components/schemas/AardRelatieEnum'
+          description:
+            'Benamingen van de aard van de relaties van andere zaken tot
+            (onderhanden) zaken.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `vervolg` - De andere zaak gaf aanleiding tot het starten van de onderhanden
+            zaak.
+
+            * `onderwerp` - De andere zaak is relevant voor cq. is onderwerp van de
+            onderhanden zaak.
+
+            * `bijdrage` - Aan het bereiken van de uitkomst van de andere zaak levert
+            de onderhanden zaak een bijdrage.'
+          title: aard relatie
+      required:
+        - aardRelatie
+        - url
+    Resultaat:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        resultaattype:
+          type: string
+          format: uri
+          description: URL-referentie naar het RESULTAATTYPE (in de Catalogi API).
+          title: resultaattype
+          maxLength: 1000
+        toelichting:
+          type: string
+          description: Een toelichting op wat het resultaat van de zaak inhoudt.
+          title: toelichting
+          maxLength: 1000
+      required:
+        - resultaattype
+        - url
+        - uuid
+        - zaak
+    ResultaatExpanded:
+     allOf:
+     - $ref: '#/components/schemas/Resultaat'
+     - properties:
+          _expand:
+            $ref: '#/components/schemas/ResultaatEmbedded'
+    ResultaatEmbedded:
+      type: object
+      properties: 
+        zaak: 
+          $ref: '#/components/schemas/ZaakExpanded'
+        resultaattype:
+          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ResultaatType'
+    Rol:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        betrokkene:
+          type: string
+          format: uri
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          title: betrokkene
+          maxLength: 1000
+        betrokkeneType:
+          allOf:
+            - $ref: '#/components/schemas/BetrokkeneTypeEnum'
+          description: 'Type van de `betrokkene`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `vestiging` - Vestiging
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `medewerker` - Medewerker'
+          title: betrokkene type
+        afwijkendeNaamBetrokkene:
+          type: string
+          description:
+            De naam van de betrokkene waaronder deze in relatie tot de
+            zaak aangesproken wil worden.
+          title: afwijkende naam betrokkene
+          maxLength: 625
+        roltype:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar een roltype binnen het ZAAKTYPE van de
+            ZAAK.
+          title: roltype
+          maxLength: 1000
+        omschrijving:
+          type: string
+          readOnly: true
+          description: Omschrijving van de aard van de ROL, afgeleid uit het ROLTYPE.
+          title: omschrijving
+        omschrijvingGeneriek:
+          type: string
+          readOnly: true
+          description:
+            "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid\
+            \ uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` -\
+            \ (Adviseur) Kennis in dienst stellen van de behandeling van (een deel\
+            \ van) een zaak.\n* `behandelaar` - (Behandelaar) De vakinhoudelijke behandeling\
+            \ doen van (een deel van) een zaak.\n* `belanghebbende` - (Belanghebbende)\
+            \ Vanuit eigen en objectief belang rechtstreeks betrokken zijn bij de\
+            \ behandeling en/of de uitkomst van een zaak.\n* `beslisser` - (Beslisser)\
+            \ Nemen van besluiten die voor de uitkomst van een zaak noodzakelijk zijn.\n\
+            * `initiator` - (Initiator) Aanleiding geven tot de start van een zaak\
+            \ ..\n* `klantcontacter` - (Klantcontacter) Het eerste aanspreekpunt zijn\
+            \ voor vragen van burgers en bedrijven ..\n* `zaakcoordinator` - (Zaakco\xF6\
+            rdinator) Er voor zorg dragen dat de behandeling van de zaak in samenhang\
+            \ uitgevoerd wordt conform de daarover gemaakte afspraken.\n* `mede_initiator`\
+            \ - Mede-initiator"
+          title: omschrijving generiek
+        roltoelichting:
+          type: string
+          title: roltoelichting
+          maxLength: 1000
+        registratiedatum:
+          type: string
+          format: date-time
+          readOnly: true
+          description: De datum waarop dit object is geregistreerd.
+          title: registratiedatum
+        indicatieMachtiging:
+          description: 'Indicatie machtiging
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `gemachtigde` - De betrokkene in de rol bij de zaak is door een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen
+
+            * `machtiginggever` - De betrokkene in de rol bij de zaak heeft een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen'
+          title: indicatie machtiging
+          oneOf:
+            - $ref: '#/components/schemas/IndicatieMachtigingEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        contactpersoonRol:
+          allOf:
+            - $ref: '#/components/schemas/ContactPersoonRol'
+          nullable: true
+          description:
+            De gegevens van de persoon die anderen desgevraagd in contact
+            brengt met medewerkers van de BETROKKENE, een NIET-NATUURLIJK PERSOON
+            of VESTIGING zijnde, of met BETROKKENE zelf, een NATUURLIJK PERSOON zijnde
+            , vanuit het belang van BETROKKENE in haar ROL bij een ZAAK.
+          title: contactpersoonRol
+        statussen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+            minLength: 1
+            maxLength: 1000
+          readOnly: true
+          description:
+            De BETROKKENE die in zijn/haar ROL in een ZAAK heeft geregistreerd
+            dat STATUSsen in die ZAAK bereikt zijn.
+          title: statussen
+          uniqueItems: true
+      required:
+        - betrokkeneType
+        - omschrijving
+        - omschrijvingGeneriek
+        - registratiedatum
+        - roltoelichting
+        - roltype
+        - statussen
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: betrokkeneType
+        mapping:
+          medewerker: '#/components/schemas/medewerker_Rol'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_Rol'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_Rol'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_Rol'
+          vestiging: '#/components/schemas/vestiging_Rol'
+    RolExpanded:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        betrokkene:
+          type: string
+          format: uri
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          title: betrokkene
+          maxLength: 1000
+        betrokkeneType:
+          allOf:
+            - $ref: '#/components/schemas/BetrokkeneTypeEnum'
+          description: 'Type van de `betrokkene`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `vestiging` - Vestiging
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `medewerker` - Medewerker'
+          title: betrokkene type
+        afwijkendeNaamBetrokkene:
+          type: string
+          description:
+            De naam van de betrokkene waaronder deze in relatie tot de
+            zaak aangesproken wil worden.
+          title: afwijkende naam betrokkene
+          maxLength: 625
+        roltype:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar een roltype binnen het ZAAKTYPE van de
+            ZAAK.
+          title: roltype
+          maxLength: 1000
+        omschrijving:
+          type: string
+          readOnly: true
+          description: Omschrijving van de aard van de ROL, afgeleid uit het ROLTYPE.
+          title: omschrijving
+        omschrijvingGeneriek:
+          type: string
+          readOnly: true
+          description:
+            "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid\
+            \ uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` -\
+            \ (Adviseur) Kennis in dienst stellen van de behandeling van (een deel\
+            \ van) een zaak.\n* `behandelaar` - (Behandelaar) De vakinhoudelijke behandeling\
+            \ doen van (een deel van) een zaak.\n* `belanghebbende` - (Belanghebbende)\
+            \ Vanuit eigen en objectief belang rechtstreeks betrokken zijn bij de\
+            \ behandeling en/of de uitkomst van een zaak.\n* `beslisser` - (Beslisser)\
+            \ Nemen van besluiten die voor de uitkomst van een zaak noodzakelijk zijn.\n\
+            * `initiator` - (Initiator) Aanleiding geven tot de start van een zaak\
+            \ ..\n* `klantcontacter` - (Klantcontacter) Het eerste aanspreekpunt zijn\
+            \ voor vragen van burgers en bedrijven ..\n* `zaakcoordinator` - (Zaakco\xF6\
+            rdinator) Er voor zorg dragen dat de behandeling van de zaak in samenhang\
+            \ uitgevoerd wordt conform de daarover gemaakte afspraken.\n* `mede_initiator`\
+            \ - Mede-initiator"
+          title: omschrijving generiek
+        roltoelichting:
+          type: string
+          title: roltoelichting
+          maxLength: 1000
+        registratiedatum:
+          type: string
+          format: date-time
+          readOnly: true
+          description: De datum waarop dit object is geregistreerd.
+          title: registratiedatum
+        indicatieMachtiging:
+          description: 'Indicatie machtiging
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `gemachtigde` - De betrokkene in de rol bij de zaak is door een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen
+
+            * `machtiginggever` - De betrokkene in de rol bij de zaak heeft een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen'
+          title: indicatie machtiging
+          oneOf:
+            - $ref: '#/components/schemas/IndicatieMachtigingEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        contactpersoonRol:
+          allOf:
+            - $ref: '#/components/schemas/ContactPersoonRol'
+          nullable: true
+          description:
+            De gegevens van de persoon die anderen desgevraagd in contact
+            brengt met medewerkers van de BETROKKENE, een NIET-NATUURLIJK PERSOON
+            of VESTIGING zijnde, of met BETROKKENE zelf, een NATUURLIJK PERSOON zijnde
+            , vanuit het belang van BETROKKENE in haar ROL bij een ZAAK.
+          title: contactpersoonRol
+        statussen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+            minLength: 1
+            maxLength: 1000
+          readOnly: true
+          description:
+            De BETROKKENE die in zijn/haar ROL in een ZAAK heeft geregistreerd
+            dat STATUSsen in die ZAAK bereikt zijn.
+          title: statussen
+          uniqueItems: true
+        _expand:
+            $ref: '#/components/schemas/RolEmbedded'
+      required:
+        - betrokkeneType
+        - omschrijving
+        - omschrijvingGeneriek
+        - registratiedatum
+        - roltoelichting
+        - roltype
+        - statussen
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: betrokkeneType
+        mapping:
+          medewerker: '#/components/schemas/medewerker_RolExpanded'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_RolExpanded'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_RolExpanded'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_RolExpanded'
+          vestiging: '#/components/schemas/vestiging_RolExpanded'
+
+    # RolExpanded:
+    #  allOf:
+    #  - $ref: '#/components/schemas/Rol'
+    #  - properties:
+    #       _expand:
+    #         $ref: '#/components/schemas/RolEmbedded'
+    RolEmbedded:
+      type: object
+      properties: 
+        zaak:
+          $ref: '#/components/schemas/ZaakExpanded'
+          example: {}
+        roltype:
+          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/RolType'
+        statussen:
+          type: array
+          items:
+            $ref: '#/components/schemas/StatusExpanded'
+    RolMedewerker:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: Een korte unieke aanduiding van de MEDEWERKER.
+          title: identificatie
+          maxLength: 24
+        achternaam:
+          type: string
+          description:
+            De achternaam zoals de MEDEWERKER die in het dagelijkse verkeer
+            gebruikt.
+          title: achternaam
+          maxLength: 200
+        voorletters:
+          type: string
+          description:
+            De verzameling letters die gevormd wordt door de eerste letter
+            van alle in volgorde voorkomende voornamen.
+          title: voorletters
+          maxLength: 20
+        voorvoegselAchternaam:
+          type: string
+          description:
+            Dat deel van de geslachtsnaam dat voorkomt in Tabel 36 (GBA),
+            voorvoegseltabel, en door een spatie van de geslachtsnaam is
+          title: voorvoegsel achternaam
+          maxLength: 10
+    RolNatuurlijkPersoon:
+      type: object
+      properties:
+        inpBsn:
+          type: string
+          description:
+            Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet
+            algemene bepalingen burgerservicenummer.
+          title: inp bsn
+          maxLength: 9
+        anpIdentificatie:
+          type: string
+          description:
+            Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NATUURLIJK PERSOON
+          title: anp identificatie
+          maxLength: 17
+        inpA_nummer:
+          type: string
+          description: Het administratienummer van de persoon, bedoeld in de Wet BRP
+          title: inp a nummer
+          pattern: ^[1-9][0-9]{9}$
+          maxLength: 10
+        geslachtsnaam:
+          type: string
+          description: De stam van de geslachtsnaam.
+          title: geslachtsnaam
+          maxLength: 200
+        voorvoegselGeslachtsnaam:
+          type: string
+          title: voorvoegsel geslachtsnaam
+          maxLength: 80
+        voorletters:
+          type: string
+          description:
+            De verzameling letters die gevormd wordt door de eerste letter
+            van alle in volgorde voorkomende voornamen.
+          title: voorletters
+          maxLength: 20
+        voornamen:
+          type: string
+          description: Voornamen bij de naam die de persoon wenst te voeren.
+          title: voornamen
+          maxLength: 200
+        geslachtsaanduiding:
+          description:
+            'Een aanduiding die aangeeft of de persoon een man of een vrouw
+            is, of dat het geslacht nog onbekend is.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `m` - Man
+
+            * `v` - Vrouw
+
+            * `o` - Onbekend'
+          title: geslachtsaanduiding
+          oneOf:
+            - $ref: '#/components/schemas/GeslachtsaanduidingEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        geboortedatum:
+          type: string
+          title: geboortedatum
+          maxLength: 18
+        verblijfsadres:
+          allOf:
+            - $ref: '#/components/schemas/VerblijfsAdres'
+          nullable: true
+          title: verblijfsadres
+        subVerblijfBuitenland:
+          allOf:
+            - $ref: '#/components/schemas/SubVerblijfBuitenland'
+          nullable: true
+          title: subVerblijfBuitenland
+    RolNietNatuurlijkPersoon:
+      type: object
+      properties:
+        innNnpId:
+          type: string
+          description:
+            Het door een kamer toegekend uniek nummer voor de INGESCHREVEN
+            NIET-NATUURLIJK PERSOON
+          title: inn nnp id
+          maxLength: 9
+        annIdentificatie:
+          type: string
+          description:
+            Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NIET-NATUURLIJK PERSOON
+          title: ann identificatie
+          maxLength: 17
+        statutaireNaam:
+          type: string
+          description:
+            Naam van de niet-natuurlijke persoon zoals deze is vastgelegd
+            in de statuten (rechtspersoon) of in de vennootschapsovereenkomst is overeengekomen
+            (Vennootschap onder firma of Commanditaire vennootschap).
+          title: statutaire naam
+          maxLength: 500
+        innRechtsvorm:
+          description: De juridische vorm van de NIET-NATUURLIJK PERSOON.
+          title: inn rechtsvorm
+          oneOf:
+            - $ref: '#/components/schemas/InnRechtsvormEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        bezoekadres:
+          type: string
+          description: De gegevens over het adres van de NIET-NATUURLIJK PERSOON
+          title: bezoekadres
+          maxLength: 1000
+        subVerblijfBuitenland:
+          allOf:
+            - $ref: '#/components/schemas/SubVerblijfBuitenland'
+          nullable: true
+          title: subVerblijfBuitenland
+    RolOrganisatorischeEenheid:
+      type: object
+      properties:
+        identificatie:
+          type: string
+          description: Een korte identificatie van de organisatorische eenheid.
+          title: identificatie
+          maxLength: 24
+        naam:
+          type: string
+          description: De feitelijke naam van de organisatorische eenheid.
+          title: naam
+          maxLength: 50
+        isGehuisvestIn:
+          type: string
+          title: is gehuisvest in
+          maxLength: 24
+    RolVestiging:
+      type: object
+      properties:
+        vestigingsNummer:
+          type: string
+          description: Een korte unieke aanduiding van de Vestiging.
+          title: vestigings nummer
+          maxLength: 24
+        handelsnaam:
+          type: array
+          items:
+            type: string
+            maxLength: 625
+          description: De naam van de vestiging waaronder gehandeld wordt.
+          title: handelsnaam
+        verblijfsadres:
+          allOf:
+            - $ref: '#/components/schemas/VerblijfsAdres'
+          nullable: true
+          title: verblijfsadres
+        subVerblijfBuitenland:
+          allOf:
+            - $ref: '#/components/schemas/SubVerblijfBuitenland'
+          nullable: true
+          title: subVerblijfBuitenland
+        kvkNummer:
+          type: string
+          description: Een uniek nummer gekoppeld aan de onderneming.
+          title: kvk nummer
+          maxLength: 8
+    Status:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        statustype:
+          type: string
+          format: uri
+          description: URL-referentie naar het STATUSTYPE (in de Catalogi API).
+          title: statustype
+          maxLength: 1000
+        datumStatusGezet:
+          type: string
+          format: date-time
+          description: De datum waarop de ZAAK de status heeft verkregen.
+          title: datum status gezet
+        statustoelichting:
+          type: string
+          description:
+            Een, voor de initiator van de zaak relevante, toelichting op
+            de status van een zaak.
+          title: statustoelichting
+          maxLength: 1000
+        indicatieLaatstGezetteStatus:
+          type: boolean
+          readOnly: true
+          description:
+            Het gegeven is afleidbaar uit de historie van de attribuutsoort
+            Datum status gezet van van alle statussen bij de desbetreffende zaak.
+          title: indicatieLaatstGezetteStatus
+        gezetdoor:
+          type: string
+          format: uri
+          title: Gezet door
+          description:
+            De BETROKKENE die in zijn/haar ROL in een ZAAK heeft geregistreerd
+            dat STATUSsen in die ZAAK bereikt zijn.
+          maxLength: 200
+        zaakinformatieobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+            minLength: 1
+            maxLength: 1000
+          readOnly: true
+          title: zaakInformatieobjecten
+          uniqueItems: true
+      required:
+        - datumStatusGezet
+        - indicatieLaatstGezetteStatus
+        - statustype
+        - url
+        - uuid
+        - zaak
+        - zaakinformatieobjecten
+    StatusExpanded:
+      allOf:
+        - $ref: '#/components/schemas/Status'
+        - properties:
+            _expand:
+              $ref: '#/components/schemas/StatusEmbedded'
+    StatusEmbedded:
+      type: object
+      properties:
+        statustype:
+          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/StatusType'
+        gezetdoor:
+          $ref: '#/components/schemas/Rol'
+        zaakinformatieobjecten:
+          type: array
+          items:
+            $ref: '#/components/schemas/ZaakInformatieObject'
+    StatusRequestbody:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        statustype:
+          type: string
+          format: uri
+          description: URL-referentie naar het STATUSTYPE (in de Catalogi API).
+          title: statustype
+          maxLength: 1000
+        datumStatusGezet:
+          type: string
+          format: date-time
+          description: De datum waarop de ZAAK de status heeft verkregen.
+          title: datum status gezet
+        statustoelichting:
+          type: string
+          description:
+            Een, voor de initiator van de zaak relevante, toelichting op
+            de status van een zaak.
+          title: statustoelichting
+          maxLength: 1000
+        indicatieLaatstGezetteStatus:
+          type: boolean
+          readOnly: true
+          description:
+            Het gegeven is afleidbaar uit de historie van de attribuutsoort
+            Datum status gezet van van alle statussen bij de desbetreffende zaak.
+          title: indicatieLaatstGezetteStatus
+        gezetdoor:
+          type: string
+          format: uri
+          title: Gezet door
+          description:
+            De BETROKKENE die in zijn/haar ROL in een ZAAK heeft geregistreerd
+            dat STATUSsen in die ZAAK bereikt zijn.
+          maxLength: 200
+      required:
+        - datumStatusGezet
+        - indicatieLaatstGezetteStatus
+        - statustype
+        - url
+        - uuid
+        - zaak
+        - zaakinformatieobjecten
+    SubVerblijfBuitenland:
+      type: object
+      properties:
+        lndLandcode:
+          type: string
+          description:
+            De code, behorende bij de landnaam, zoals opgenomen in de Land/Gebied-tabel
+            van de BRP.
+          title: lnd landcode
+          maxLength: 4
+        lndLandnaam:
+          type: string
+          description:
+            De naam van het land, zoals opgenomen in de Land/Gebied-tabel
+            van de BRP.
+          title: lnd landnaam
+          maxLength: 40
+        subAdresBuitenland_1:
+          type: string
+          title: sub adres buitenland 1
+          maxLength: 35
+        subAdresBuitenland_2:
+          type: string
+          title: sub adres buitenland 2
+          maxLength: 35
+        subAdresBuitenland_3:
+          type: string
+          title: sub adres buitenland 3
+          maxLength: 35
+      required:
+        - lndLandcode
+        - lndLandnaam
+    TerreinGebouwdObjectAdres:
+      type: object
+      properties:
+        numIdentificatie:
+          type: string
+          title: num identificatie
+          maxLength: 100
+        oaoIdentificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        wplWoonplaatsNaam:
+          type: string
+          title: wpl woonplaats naam
+          maxLength: 80
+        gorOpenbareRuimteNaam:
+          type: string
+          description:
+            Een door het bevoegde gemeentelijke orgaan aan een OPENBARE
+            RUIMTE toegekende benaming
+          title: gor openbare ruimte naam
+          maxLength: 80
+        aoaPostcode:
+          type: string
+          title: postcode
+          maxLength: 7
+        aoaHuisnummer:
+          type: integer
+          maximum: 99999
+          minimum: 0
+          title: huisnummer
+        aoaHuisletter:
+          type: string
+          title: huisletter
+          maxLength: 1
+        aoaHuisnummertoevoeging:
+          type: string
+          title: huisnummertoevoeging
+          maxLength: 4
+        ogoLocatieAanduiding:
+          type: string
+          title: locatie aanduiding
+          maxLength: 100
+      required:
+        - aoaHuisnummer
+        - gorOpenbareRuimteNaam
+        - oaoIdentificatie
+        - wplWoonplaatsNaam
+    TypeWaterdeelEnum:
+      enum:
+        - zee
+        - waterloop
+        - watervlakte
+        - greppel_droge_sloot
+      type: string
+    ValidatieFout:
+      type: object
+      description: Formaat van HTTP 4xx en 5xx fouten.
+      properties:
+        type:
+          type: string
+          description: URI referentie naar het type fout, bedoeld voor developers
+          title: type
+        code:
+          type: string
+          description: Systeemcode die het type fout aangeeft
+          title: code
+        title:
+          type: string
+          description: Generieke titel voor het type fout
+          title: title
+        status:
+          type: integer
+          description: De HTTP status code
+          title: status
+        detail:
+          type: string
+          description: Extra informatie bij de fout, indien beschikbaar
+          title: detail
+        instance:
+          type: string
+          description:
+            URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          title: instance
+        invalidParams:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldValidationError'
+          title: invalidParams
+      required:
+        - code
+        - detail
+        - instance
+        - invalidParams
+        - status
+        - title
+    VerblijfsAdres:
+      type: object
+      properties:
+        aoaIdentificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        wplWoonplaatsNaam:
+          type: string
+          title: wpl woonplaats naam
+          maxLength: 80
+        gorOpenbareRuimteNaam:
+          type: string
+          description:
+            Een door het bevoegde gemeentelijke orgaan aan een OPENBARE
+            RUIMTE toegekende benaming
+          title: gor openbare ruimte naam
+          maxLength: 80
+        aoaPostcode:
+          type: string
+          title: postcode
+          maxLength: 7
+        aoaHuisnummer:
+          type: integer
+          maximum: 99999
+          minimum: 0
+          title: huisnummer
+        aoaHuisletter:
+          type: string
+          title: huisletter
+          maxLength: 1
+        aoaHuisnummertoevoeging:
+          type: string
+          title: huisnummertoevoeging
+          maxLength: 4
+        inpLocatiebeschrijving:
+          type: string
+          title: locatie omschrijving
+          maxLength: 1000
+      required:
+        - aoaHuisnummer
+        - aoaIdentificatie
+        - gorOpenbareRuimteNaam
+        - wplWoonplaatsNaam
+    Verlenging:
+      type: object
+      description:
+        Gegevens omtrent het verlengen van de doorlooptijd van de behandeling
+        van de ZAAK
+      properties:
+        reden:
+          type: string
+          description:
+            Omschrijving van de reden voor het verlengen van de behandeling
+            van de zaak.
+          title: reden verlenging
+          maxLength: 200
+        duur:
+          type: string
+          description:
+            Het aantal werkbare dagen waarmee de doorlooptijd van de behandeling
+            van de ZAAK is verlengd (of verkort) ten opzichte van de eerder gecommuniceerde
+            doorlooptijd.
+          title: duur verlenging
+          format: duration
+      required:
+        - duur
+        - reden
+      nullable: true
+    VertrouwelijkheidaanduidingEnum:
+      enum:
+        - openbaar
+        - beperkt_openbaar
+        - intern
+        - zaakvertrouwelijk
+        - vertrouwelijk
+        - confidentieel
+        - geheim
+        - zeer_geheim
+      type: string
+    Wijzigingen:
+      type: object
+      properties:
+        oud:
+          type: object
+          additionalProperties: {}
+          description:
+            Volledige JSON body van het object zoals dat bestond voordat
+            de actie heeft plaatsgevonden.
+          title: oud
+        nieuw:
+          type: object
+          additionalProperties: {}
+          description: Volledige JSON body van het object na de actie.
+          title: nieuw
+    WozObjectAdres:
+      type: object
+      properties:
+        aoaIdentificatie:
+          type: string
+          description: De unieke identificatie van het OBJECT
+          title: identificatie
+          maxLength: 100
+        wplWoonplaatsNaam:
+          type: string
+          title: wpl woonplaats naam
+          maxLength: 80
+        gorOpenbareRuimteNaam:
+          type: string
+          description:
+            Een door het bevoegde gemeentelijke orgaan aan een OPENBARE
+            RUIMTE toegekende benaming
+          title: gor openbare ruimte naam
+          maxLength: 80
+        aoaPostcode:
+          type: string
+          title: postcode
+          maxLength: 7
+        aoaHuisnummer:
+          type: integer
+          maximum: 99999
+          minimum: 0
+          title: huisnummer
+        aoaHuisletter:
+          type: string
+          title: huisletter
+          maxLength: 1
+        aoaHuisnummertoevoeging:
+          type: string
+          title: huisnummertoevoeging
+          maxLength: 4
+        locatieOmschrijving:
+          type: string
+          title: locatie omschrijving
+          maxLength: 1000
+      required:
+        - aoaHuisnummer
+        - aoaIdentificatie
+        - gorOpenbareRuimteNaam
+        - wplWoonplaatsNaam
+    Zaak:
+      type: object
+      description: 'Set gegevensgroepdata from validated nested data.
+
+
+        Usage: include the mixin on the ModelSerializer that has gegevensgroepen.'
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        identificatie:
+          type: string
+          description:
+            De unieke identificatie van de ZAAK binnen de organisatie die
+            verantwoordelijk is voor de behandeling van de ZAAK.
+          title: identificatie
+          maxLength: 40
+        bronorganisatie:
+          type: string
+          description:
+            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie
+            die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers
+            en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
+          title: bronorganisatie
+          maxLength: 9
+        omschrijving:
+          type: string
+          description: Een korte omschrijving van de zaak.
+          title: omschrijving
+          maxLength: 80
+        toelichting:
+          type: string
+          description: Een toelichting op de zaak.
+          title: toelichting
+          maxLength: 1000
+        zaaktype:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar het ZAAKTYPE (in de Catalogi API) in de
+            CATALOGUS waar deze voorkomt
+          title: zaaktype
+          maxLength: 1000
+        registratiedatum:
+          type: string
+          format: date
+          description:
+            De datum waarop de zaakbehandelende organisatie de ZAAK heeft
+            geregistreerd. Indien deze niet opgegeven wordt, wordt de datum van vandaag
+            gebruikt.
+          title: registratiedatum
+        verantwoordelijkeOrganisatie:
+          type: string
+          description:
+            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie
+            die eindverantwoordelijk is voor de behandeling van de zaak. Dit moet
+            een geldig RSIN zijn van 9 nummers en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
+          title: verantwoordelijke organisatie
+          maxLength: 9
+        startdatum:
+          type: string
+          format: date
+          description: De datum waarop met de uitvoering van de zaak is gestart
+          title: startdatum
+        einddatum:
+          type: string
+          format: date
+          readOnly: true
+          nullable: true
+          description: De datum waarop de uitvoering van de zaak afgerond is.
+          title: einddatum
+        einddatumGepland:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De datum waarop volgens de planning verwacht wordt dat de zaak
+            afgerond wordt.
+          title: einddatum gepland
+        uiterlijkeEinddatumAfdoening:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De laatste datum waarop volgens wet- en regelgeving de zaak
+            afgerond dient te zijn.
+          title: uiterlijke einddatum afdoening
+        publicatiedatum:
+          type: string
+          format: date
+          nullable: true
+          description: Datum waarop (het starten van) de zaak gepubliceerd is of wordt.
+          title: publicatiedatum
+        communicatiekanaal:
+          type: string
+          format: uri
+          description:
+            Het medium waarlangs de aanleiding om een zaak te starten is
+            ontvangen. URL naar een communicatiekanaal in de VNG-Referentielijst van
+            communicatiekanalen.
+          title: communicatiekanaal
+          maxLength: 1000
+        productenOfDiensten:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: URL naar product/dienst
+            maxLength: 1000
+          description:
+            De producten en/of diensten die door de zaak worden voortgebracht.
+            Dit zijn URLs naar de resources zoals die door de producten- en dienstencatalogus-API
+            wordt ontsloten. De producten/diensten moeten bij het zaaktype vermeld
+            zijn.
+          title: producten of diensten
+        vertrouwelijkheidaanduiding:
+          allOf:
+            - $ref: '#/components/schemas/VertrouwelijkheidaanduidingEnum'
+          title: Vertrouwlijkheidaanduiding
+          description:
+            Aanduiding van de mate waarin het zaakdossier van de ZAAK voor
+            de openbaarheid bestemd is. Optioneel - indien geen waarde gekozen wordt,
+            dan wordt de waarde van het ZAAKTYPE overgenomen. Dit betekent dat de
+            API _altijd_ een waarde teruggeeft.
+        betalingsindicatie:
+          description:
+            'Indicatie of de, met behandeling van de zaak gemoeide, kosten
+            betaald zijn door de desbetreffende betrokkene.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `nvt` - Er is geen sprake van te betalen, met de zaak gemoeide, kosten.
+
+            * `nog_niet` - De met de zaak gemoeide kosten zijn (nog) niet betaald.
+
+            * `gedeeltelijk` - De met de zaak gemoeide kosten zijn gedeeltelijk betaald.
+
+            * `geheel` - De met de zaak gemoeide kosten zijn geheel betaald.'
+          title: betalingsindicatie
+          oneOf:
+            - $ref: '#/components/schemas/BetalingsindicatieEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        betalingsindicatieWeergave:
+          type: string
+          readOnly: true
+          description: Uitleg bij `betalingsindicatie`.
+          title: betalingsindicatieWeergave
+        laatsteBetaaldatum:
+          type: string
+          format: date-time
+          nullable: true
+          description:
+            De datum waarop de meest recente betaling is verwerkt van kosten
+            die gemoeid zijn met behandeling van de zaak.
+          title: laatste betaaldatum
+        zaakgeometrie:
+          allOf:
+            - $ref: '#/components/schemas/GeoJSONGeometry'
+          nullable: true
+          description: Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON.
+          title: zaakgeometrie
+        verlenging:
+          allOf:
+            - $ref: '#/components/schemas/Verlenging'
+          nullable: true
+          description:
+            Gegevens omtrent het verlengen van de doorlooptijd van de behandeling
+            van de ZAAK
+          title: verlenging
+        opschorting:
+          allOf:
+            - $ref: '#/components/schemas/Opschorting'
+          nullable: true
+          description:
+            Gegevens omtrent het tijdelijk opschorten van de behandeling
+            van de ZAAK
+          title: opschorting
+        selectielijstklasse:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar de categorie in de gehanteerde 'Selectielijst
+            Archiefbescheiden' die, gezien het zaaktype en het resultaattype van de
+            zaak, bepalend is voor het archiefregime van de zaak.
+          title: selectielijstklasse
+          maxLength: 1000
+        hoofdzaak:
+          type: string
+          format: uri
+          nullable: true
+          title: Is deelzaak van
+          description:
+            "URL-referentie naar de ZAAK, waarom verzocht is door de initiator\
+            \ daarvan, die behandeld wordt in twee of meer separate ZAAKen waarvan\
+            \ de onderhavige ZAAK er \xE9\xE9n is."
+          minLength: 1
+          maxLength: 1000
+        deelzaken:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          description: URL-referenties naar deel ZAAKen.
+          title: is deelzaak van
+          uniqueItems: true
+        relevanteAndereZaken:
+          type: array
+          items:
+            $ref: '#/components/schemas/RelevanteZaak'
+          description: Een lijst van relevante andere zaken.
+          title: zaak
+        eigenschappen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        rollen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        status:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description: Indien geen status bekend is, dan is de waarde 'null'
+          title: status
+        zaakinformatieobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        zaakobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          title: zaak
+          uniqueItems: true
+        kenmerken:
+          type: array
+          items:
+            $ref: '#/components/schemas/ZaakKenmerk'
+          description:
+            Lijst van kenmerken. Merk op dat refereren naar gerelateerde
+            objecten beter kan via `ZaakObject`.
+          title: zaak
+        archiefnominatie:
+          nullable: true
+          description:
+            'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum
+            overgedragen worden naar een archiefbewaarplaats.
+
+            * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd
+            worden.'
+          title: archiefnominatie
+          oneOf:
+            - $ref: '#/components/schemas/ArchiefnominatieEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+            - $ref: '#/components/schemas/NullEnum'
+        archiefstatus:
+          allOf:
+            - $ref: '#/components/schemas/ArchiefstatusEnum'
+          description:
+            'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+            termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `nog_te_archiveren` - De zaak cq. het zaakdossier is nog niet als geheel
+            gearchiveerd.
+
+            * `gearchiveerd` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar
+            bewaarbaar gemaakt.
+
+            * `gearchiveerd_procestermijn_onbekend` - De zaak cq. het zaakdossier
+            is als geheel niet-wijzigbaar bewaarbaar gemaakt maar de vernietigingsdatum
+            kan nog niet bepaald worden.
+
+            * `overgedragen` - De zaak cq. het zaakdossier is overgebracht naar een
+            archiefbewaarplaats.'
+          title: archiefstatus
+        archiefactiedatum:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De datum waarop het gearchiveerde zaakdossier vernietigd moet
+            worden dan wel overgebracht moet worden naar een archiefbewaarplaats.
+            Wordt automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT
+            aan deze ZAAK indien nog leeg.
+          title: archiefactiedatum
+        resultaat:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description:
+            URL-referentie naar het RESULTAAT. Indien geen resultaat bekend
+            is, dan is de waarde 'null'
+          title: resultaat
+        opdrachtgevendeOrganisatie:
+          type: string
+          description:
+            De krachtens publiekrecht ingestelde rechtspersoon dan wel
+            ander niet-natuurlijk persoon waarbinnen het (bestuurs)orgaan zetelt dat
+            opdracht heeft gegeven om taken uit te voeren waaraan de zaak invulling
+            geeft.
+          title: opdrachtgevende organisatie
+          maxLength: 9
+        processobjectaard:
+          type: string
+          nullable: true
+          title: Procesobjectaard
+          description:
+            Omschrijving van het object, subject of gebeurtenis waarop,
+            vanuit archiveringsoptiek, de zaak betrekking heeft.
+          maxLength: 200
+        startdatumBewaartermijn:
+          type: string
+          format: date
+          nullable: true
+          description:
+            De datum die de start markeert van de termijn waarop het zaakdossier
+            vernietigd moet worden.
+          title: startdatum bewaartermijn
+        processobject:
+          allOf:
+            - $ref: '#/components/schemas/Processobject'
+          nullable: true
+          description:
+            Specificatie van de attribuutsoort van het object, subject
+            of gebeurtenis  waarop, vanuit archiveringsoptiek, de zaak betrekking
+            heeft en dat bepalend is voor de start van de archiefactietermijn.
+          title: processobject
+      required:
+        - betalingsindicatieWeergave
+        - bronorganisatie
+        - deelzaken
+        - eigenschappen
+        - einddatum
+        - resultaat
+        - rollen
+        - startdatum
+        - status
+        - url
+        - uuid
+        - verantwoordelijkeOrganisatie
+        - zaakinformatieobjecten
+        - zaakobjecten
+        - zaaktype
+    ZaakExpanded:
+     allOf:
+     - $ref: '#/components/schemas/Zaak'
+     - properties:
+          _expand:
+            $ref: '#/components/schemas/ZaakEmbedded'
+    ZaakEmbedded:
+      type: object
+      description: "<b>Let op</b>: de definities van onderstaande attributen kunnen recursie bevatten en worden mogelijk niet goed weergegeven in de gegenereerde voorbeeldberichten van Redoc of Swagger. 
+        Check altijd de yaml-specificitie voor correcte interpretatie en gebruik de referentie-implementatie om correcte responsberichten te genereren."
+      properties: 
+        zaaktype:
+           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakType'
+        hoofdzaak:
+          oneOf:
+            - $ref: '#/components/schemas/ZaakExpanded' 
+            - $ref: '#/components/schemas/EmptyObject' 
+          example: {}
+        deelzaken:
+          type: array
+          items: 
+            $ref: '#/components/schemas/ZaakExpanded'
+          example: [{}]
+        relevanteAndereZaken:
+          type: array
+          items: 
+            $ref: '#/components/schemas/ZaakExpanded'
+          example: [{}]
+        eigenschappen: 
+          type: array
+          items: 
+            $ref: '#/components/schemas/ZaakEigenschap'      
+        rollen: 
+          type: array
+          items: 
+            $ref: '#/components/schemas/RolExpanded'   
+        status:
+          oneOf:
+          - $ref: '#/components/schemas/StatusExpanded'
+          - $ref: '#/components/schemas/EmptyObject'
+        zaakobjecten:
+          type: array
+          items: 
+           $ref: '#/components/schemas/ZaakObjectExpanded'
+        resultaat:
+          oneOf:
+          - $ref: '#/components/schemas/ResultaatExpanded'
+          - $ref: '#/components/schemas/EmptyObject'
+    EmptyObject:
+      type: object
+      description: Leeg object. Dit wordt teruggeven indien het te expanderen veld een null waarde heeft.
+      example: {}
+    ZaakBesluit:
+      type: object
+      description:
+        "A type of `ModelSerializer` that uses hyperlinked relationships
+        with compound keys instead
+
+        of primary key relationships.  Specifically:
+
+
+        * A 'url' field is included instead of the 'id' field.
+
+        * Relationships to other instances are hyperlinks, instead of primary keys.
+
+
+        NOTE: this only works with DRF 3.1.0 and above."
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        besluit:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar het BESLUIT (in de Besluiten API), waar
+            ook de relatieinformatie opgevraagd kan worden.
+          title: besluit
+          maxLength: 1000
+      required:
+        - besluit
+        - url
+        - uuid
+    ZaakContactMoment:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        contactmoment:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar het CONTACTMOMENT (in de Klantinteractie
+            API)
+          title: contactmoment
+          maxLength: 1000
+      required:
+        - contactmoment
+        - url
+        - uuid
+        - zaak
+    ZaakEigenschap:
+      type: object
+      description:
+        "A type of `ModelSerializer` that uses hyperlinked relationships
+        with compound keys instead
+
+        of primary key relationships.  Specifically:
+
+
+        * A 'url' field is included instead of the 'id' field.
+
+        * Relationships to other instances are hyperlinks, instead of primary keys.
+
+
+        NOTE: this only works with DRF 3.1.0 and above."
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          title: zaak
+        eigenschap:
+          type: string
+          format: uri
+          description: URL-referentie naar de EIGENSCHAP (in de Catalogi API).
+          title: eigenschap
+          maxLength: 1000
+        naam:
+          type: string
+          readOnly: true
+          description: De naam van de EIGENSCHAP (overgenomen uit de Catalogi API).
+          title: ' naam'
+        waarde:
+          type: string
+          title: waarde
+      required:
+        - eigenschap
+        - naam
+        - url
+        - uuid
+        - waarde
+        - zaak
+    ZaakInformatieObject:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        informatieobject:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar het INFORMATIEOBJECT (in de Documenten
+            API), waar ook de relatieinformatie opgevraagd kan worden.
+          title: informatieobject
+          maxLength: 1000
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        aardRelatieWeergave:
+          allOf:
+            - $ref: '#/components/schemas/AardRelatieWeergaveEnum'
+          readOnly: true
+          title: aardRelatieWeergave
+        titel:
+          type: string
+          description:
+            De naam waaronder het INFORMATIEOBJECT binnen het OBJECT bekend
+            is.
+          title: titel
+          maxLength: 200
+        beschrijving:
+          type: string
+          description:
+            Een op het object gerichte beschrijving van de inhoud vanhet
+            INFORMATIEOBJECT.
+          title: beschrijving
+        registratiedatum:
+          type: string
+          format: date-time
+          readOnly: true
+          description:
+            De datum waarop de behandelende organisatie het INFORMATIEOBJECT
+            heeft geregistreerd bij het OBJECT. Geldige waardes zijn datumtijden gelegen
+            op of voor de huidige datum en tijd.
+          title: registratiedatum
+        vernietigingsdatum:
+          type: string
+          format: date-time
+          nullable: true
+          description:
+            De datum waarop het informatieobject uit het zaakdossier verwijderd
+            moet worden.
+          title: vernietigingsdatum
+        status:
+          type: string
+          format: uri
+          nullable: true
+          description:
+            De bij de desbetreffende ZAAK behorende STATUS waarvoor het
+            ZAAK-INFORMATIEOBJECT relevant is (geweest) met het oog op het bereiken
+            van die STATUS en/of de communicatie daarover.
+          title: status
+          minLength: 1
+          maxLength: 1000
+      required:
+        - aardRelatieWeergave
+        - informatieobject
+        - registratiedatum
+        - url
+        - uuid
+        - zaak
+    ZaakInformatieObjectExpanded:
+     allOf:
+     - $ref: '#/components/schemas/ZaakInformatieObject'
+     - properties:
+          _expand:
+            $ref: '#/components/schemas/ZaakInformatieObjectEmbedded'
+    ZaakInformatieObjectEmbedded:
+      type: object
+      properties: 
+        status:
+          $ref: '#/components/schemas/StatusExpanded'
+    ZaakKenmerk:
+      type: object
+      properties:
+        kenmerk:
+          type: string
+          description: Identificeert uniek de zaak in een andere administratie.
+          title: kenmerk
+          maxLength: 40
+        bron:
+          type: string
+          description: De aanduiding van de administratie waar het kenmerk op slaat.
+          title: bron
+          maxLength: 40
+      required:
+        - bron
+        - kenmerk
+    ZaakObject:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        object:
+          type: string
+          format: uri
+          description: URL-referentie naar de resource die het OBJECT beschrijft.
+          title: object
+          maxLength: 1000
+        zaakobjecttype:
+          type: string
+          format: uri
+          description: URL-referentie naar het ZAAKOBJECTTYPE (in de Catalogi API).
+          title: zaakobjecttype
+          maxLength: 1000
+        objectType:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeEnum'
+          description:
+            'Beschrijft het type OBJECT gerelateerd aan de ZAAK. Als er
+            geen passend type is, dan moet het type worden opgegeven onder `objectTypeOverige`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `adres` - Adres
+
+            * `besluit` - Besluit
+
+            * `buurt` - Buurt
+
+            * `enkelvoudig_document` - Enkelvoudig document
+
+            * `gemeente` - Gemeente
+
+            * `gemeentelijke_openbare_ruimte` - Gemeentelijke openbare ruimte
+
+            * `huishouden` - Huishouden
+
+            * `inrichtingselement` - Inrichtingselement
+
+            * `kadastrale_onroerende_zaak` - Kadastrale onroerende zaak
+
+            * `kunstwerkdeel` - Kunstwerkdeel
+
+            * `maatschappelijke_activiteit` - Maatschappelijke activiteit
+
+            * `medewerker` - Medewerker
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `openbare_ruimte` - Openbare ruimte
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `pand` - Pand
+
+            * `spoorbaandeel` - Spoorbaandeel
+
+            * `status` - Status
+
+            * `terreindeel` - Terreindeel
+
+            * `terrein_gebouwd_object` - Terrein gebouwd object
+
+            * `vestiging` - Vestiging
+
+            * `waterdeel` - Waterdeel
+
+            * `wegdeel` - Wegdeel
+
+            * `wijk` - Wijk
+
+            * `woonplaats` - Woonplaats
+
+            * `woz_deelobject` - Woz deel object
+
+            * `woz_object` - Woz object
+
+            * `woz_waarde` - Woz waarde
+
+            * `zakelijk_recht` - Zakelijk recht
+
+            * `overige` - Overige'
+          title: object type
+        objectTypeOverige:
+          type: string
+          description:
+            Beschrijft het type OBJECT als `objectType` de waarde "overige"
+            heeft.
+          title: object type overige
+          pattern: '[a-z\_]+'
+          maxLength: 100
+        objectTypeOverigeDefinitie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeOverigeDefinitie'
+          nullable: true
+          title: definitie object type overige
+          description:
+            'Verwijzing naar het schema van het type OBJECT als `objectType`
+            de waarde "overige" heeft.
+
+
+            * De URL referentie moet naar een JSON endpoint   wijzen waarin het objecttype
+            gedefinieerd is, inclusief het   [JSON-schema](https://json-schema.org/).
+
+            * Gebruik het `schema` attribuut om te verwijzen naar het schema binnen   de
+            objecttype resource (deze gebruikt het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+            * Gebruik het `objectData` attribuut om te verwijzen naar de gegevens   binnen
+            het OBJECT. Deze gebruikt ook het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+
+            Indien je hier gebruikt van maakt, dan moet je een OBJECT url opgeven
+            en is het gebruik van objectIdentificatie niet mogelijk. De opgegeven
+            OBJECT url wordt gevalideerd tegen het schema van het opgegeven objecttype.'
+        relatieomschrijving:
+          type: string
+          description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
+          title: relatieomschrijving
+          maxLength: 80
+      required:
+        - objectType
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: objectType
+        mapping:
+          adres: '#/components/schemas/adres_ZaakObject'
+          besluit: '#/components/schemas/besluit_ZaakObject'
+          buurt: '#/components/schemas/buurt_ZaakObject'
+          enkelvoudig_document: '#/components/schemas/enkelvoudig_document_ZaakObject'
+          gemeente: '#/components/schemas/gemeente_ZaakObject'
+          gemeentelijke_openbare_ruimte: '#/components/schemas/gemeentelijke_openbare_ruimte_ZaakObject'
+          huishouden: '#/components/schemas/huishouden_ZaakObject'
+          inrichtingselement: '#/components/schemas/inrichtingselement_ZaakObject'
+          kadastrale_onroerende_zaak: '#/components/schemas/kadastrale_onroerende_zaak_ZaakObject'
+          kunstwerkdeel: '#/components/schemas/kunstwerkdeel_ZaakObject'
+          maatschappelijke_activiteit: '#/components/schemas/maatschappelijke_activiteit_ZaakObject'
+          medewerker: '#/components/schemas/medewerker_ZaakObject'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_ZaakObject'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_ZaakObject'
+          openbare_ruimte: '#/components/schemas/openbare_ruimte_ZaakObject'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_ZaakObject'
+          pand: '#/components/schemas/pand_ZaakObject'
+          spoorbaandeel: '#/components/schemas/spoorbaandeel_ZaakObject'
+          status: '#/components/schemas/status_ZaakObject'
+          terreindeel: '#/components/schemas/terreindeel_ZaakObject'
+          terrein_gebouwd_object: '#/components/schemas/terrein_gebouwd_object_ZaakObject'
+          vestiging: '#/components/schemas/vestiging_ZaakObject'
+          waterdeel: '#/components/schemas/waterdeel_ZaakObject'
+          wegdeel: '#/components/schemas/wegdeel_ZaakObject'
+          wijk: '#/components/schemas/wijk_ZaakObject'
+          woonplaats: '#/components/schemas/woonplaats_ZaakObject'
+          woz_deelobject: '#/components/schemas/woz_deelobject_ZaakObject'
+          woz_object: '#/components/schemas/woz_object_ZaakObject'
+          woz_waarde: '#/components/schemas/woz_waarde_ZaakObject'
+          zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObject'
+          overige: '#/components/schemas/overige_ZaakObject'
+    ZaakObjectExpanded:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        object:
+          type: string
+          format: uri
+          description: URL-referentie naar de resource die het OBJECT beschrijft.
+          title: object
+          maxLength: 1000
+        zaakobjecttype:
+          type: string
+          format: uri
+          description: URL-referentie naar het ZAAKOBJECTTYPE (in de Catalogi API).
+          title: zaakobjecttype
+          maxLength: 1000
+        objectType:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeEnum'
+          description:
+            'Beschrijft het type OBJECT gerelateerd aan de ZAAK. Als er
+            geen passend type is, dan moet het type worden opgegeven onder `objectTypeOverige`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `adres` - Adres
+
+            * `besluit` - Besluit
+
+            * `buurt` - Buurt
+
+            * `enkelvoudig_document` - Enkelvoudig document
+
+            * `gemeente` - Gemeente
+
+            * `gemeentelijke_openbare_ruimte` - Gemeentelijke openbare ruimte
+
+            * `huishouden` - Huishouden
+
+            * `inrichtingselement` - Inrichtingselement
+
+            * `kadastrale_onroerende_zaak` - Kadastrale onroerende zaak
+
+            * `kunstwerkdeel` - Kunstwerkdeel
+
+            * `maatschappelijke_activiteit` - Maatschappelijke activiteit
+
+            * `medewerker` - Medewerker
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `openbare_ruimte` - Openbare ruimte
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `pand` - Pand
+
+            * `spoorbaandeel` - Spoorbaandeel
+
+            * `status` - Status
+
+            * `terreindeel` - Terreindeel
+
+            * `terrein_gebouwd_object` - Terrein gebouwd object
+
+            * `vestiging` - Vestiging
+
+            * `waterdeel` - Waterdeel
+
+            * `wegdeel` - Wegdeel
+
+            * `wijk` - Wijk
+
+            * `woonplaats` - Woonplaats
+
+            * `woz_deelobject` - Woz deel object
+
+            * `woz_object` - Woz object
+
+            * `woz_waarde` - Woz waarde
+
+            * `zakelijk_recht` - Zakelijk recht
+
+            * `overige` - Overige'
+          title: object type
+        objectTypeOverige:
+          type: string
+          description:
+            Beschrijft het type OBJECT als `objectType` de waarde "overige"
+            heeft.
+          title: object type overige
+          pattern: '[a-z\_]+'
+          maxLength: 100
+        objectTypeOverigeDefinitie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeOverigeDefinitie'
+          nullable: true
+          title: definitie object type overige
+          description:
+            'Verwijzing naar het schema van het type OBJECT als `objectType`
+            de waarde "overige" heeft.
+
+
+            * De URL referentie moet naar een JSON endpoint   wijzen waarin het objecttype
+            gedefinieerd is, inclusief het   [JSON-schema](https://json-schema.org/).
+
+            * Gebruik het `schema` attribuut om te verwijzen naar het schema binnen   de
+            objecttype resource (deze gebruikt het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+            * Gebruik het `objectData` attribuut om te verwijzen naar de gegevens   binnen
+            het OBJECT. Deze gebruikt ook het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+
+            Indien je hier gebruikt van maakt, dan moet je een OBJECT url opgeven
+            en is het gebruik van objectIdentificatie niet mogelijk. De opgegeven
+            OBJECT url wordt gevalideerd tegen het schema van het opgegeven objecttype.'
+        relatieomschrijving:
+          type: string
+          description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
+          title: relatieomschrijving
+          maxLength: 80
+        _expand:
+            $ref: '#/components/schemas/ZaakObjectEmbedded'
+      required:
+        - objectType
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: objectType
+        mapping:
+          adres: '#/components/schemas/adres_ZaakObjectExpanded'
+          besluit: '#/components/schemas/besluit_ZaakObjectExpanded'
+          buurt: '#/components/schemas/buurt_ZaakObjectExpanded'
+          enkelvoudig_document: '#/components/schemas/enkelvoudig_document_ZaakObjectExpanded'
+          gemeente: '#/components/schemas/gemeente_ZaakObjectExpanded'
+          gemeentelijke_openbare_ruimte: '#/components/schemas/gemeentelijke_openbare_ruimte_ZaakObjectExpanded'
+          huishouden: '#/components/schemas/huishouden_ZaakObjectExpanded'
+          inrichtingselement: '#/components/schemas/inrichtingselement_ZaakObjectExpanded'
+          kadastrale_onroerende_zaak: '#/components/schemas/kadastrale_onroerende_zaak_ZaakObjectExpanded'
+          kunstwerkdeel: '#/components/schemas/kunstwerkdeel_ZaakObjectExpanded'
+          maatschappelijke_activiteit: '#/components/schemas/maatschappelijke_activiteit_ZaakObjectExpanded'
+          medewerker: '#/components/schemas/medewerker_ZaakObjectExpanded'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_ZaakObjectExpanded'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_ZaakObjectExpanded'
+          openbare_ruimte: '#/components/schemas/openbare_ruimte_ZaakObjectExpanded'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_ZaakObjectExpanded'
+          pand: '#/components/schemas/pand_ZaakObjectExpanded'
+          spoorbaandeel: '#/components/schemas/spoorbaandeel_ZaakObjectExpanded'
+          status: '#/components/schemas/status_ZaakObjectExpanded'
+          terreindeel: '#/components/schemas/terreindeel_ZaakObjectExpanded'
+          terrein_gebouwd_object: '#/components/schemas/terrein_gebouwd_object_ZaakObjectExpanded'
+          vestiging: '#/components/schemas/vestiging_ZaakObjectExpanded'
+          waterdeel: '#/components/schemas/waterdeel_ZaakObjectExpanded'
+          wegdeel: '#/components/schemas/wegdeel_ZaakObjectExpanded'
+          wijk: '#/components/schemas/wijk_ZaakObjectExpanded'
+          woonplaats: '#/components/schemas/woonplaats_ZaakObjectExpanded'
+          woz_deelobject: '#/components/schemas/woz_deelobject_ZaakObjectExpanded'
+          woz_object: '#/components/schemas/woz_object_ZaakObjectExpanded'
+          woz_waarde: '#/components/schemas/woz_waarde_ZaakObjectExpanded'
+          zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObjectExpanded'
+          overige: '#/components/schemas/overige_ZaakObjectExpanded'
+    ZaakObjectEmbedded:
+      type: object
+      properties: 
+        zaakobjecttype:
+          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'
+    ZaakVerzoek:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        verzoek:
+          type: string
+          format: uri
+          description: URL-referentie naar het VERZOEK (in de Klantinteractie API)
+          title: verzoek
+          maxLength: 1000
+      required:
+        - url
+        - uuid
+        - verzoek
+        - zaak
+    ZaakZoek:
+          type: object
+          properties:
+            zaakgeometrie:
+              $ref: '#/components/schemas/GeoWithin'
+            uuid__in:
+              description: Array of unieke resource identifiers (UUID4)
+              type: array
+              items:
+                type: string
+                format: uuid
+              example: ["e80b7507-199a-484c-ad49-c41a1e43a6e7", "78e12133-c467-4202-91ba-4417baa52801"]
+            identificatie:
+              title: Identificatie
+              description: De unieke identificatie van de ZAAK binnen de organisatie die
+                verantwoordelijk is voor de behandeling van de ZAAK.
+              type: string
+              example: "zaak123"
+            bronorganisatie:
+              title: Bronorganisatie
+              description: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie
+                die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers
+                en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
+              type: string
+              example: "000000000"
+            bronorganisatie__in:
+              description: Array van bronorganisaties.
+              type: array
+              items:
+                type: string
+                format: string
+              example: ["000000000","479559740","875883461"]
+            zaaktype:
+              title: Zaaktype
+              description: URL-referentie naar het ZAAKTYPE (in de Catalogi API) in de
+                CATALOGUS waar deze voorkomt
+              type: string
+              example: "https://catalogi-api.test.vng.cloud/api/v1/zaaktypen/e80b7507-199a-484c-ad49-c41a1e43a6e7"
+            zaaktype__in:
+              description: Array van zaaktypen.
+              type: array
+              items:
+                type: string
+                format: uri
+              example: ["https://catalogi-api.test.vng.cloud/api/v1/zaaktypen/e80b7507-199a-484c-ad49-c41a1e43a6e7","https://catalogi-api.test.vng.cloud/api/v1/zaaktypen/78e12133-c467-4202-91ba-4417baa52801"]
+            archiefnominatie:
+              title: Archiefnominatie
+              description: 'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+                termijn vernietigd moet worden.
+                Uitleg bij mogelijke waarden:
+                * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum
+                overgedragen worden naar een archiefbewaarplaats.
+                * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd
+                worden.'
+              type: string
+              enum:
+              - blijvend_bewaren
+              - vernietigen
+              example: "blijvend_bewaren"
+            archiefnominatie__in:
+              title: Archiefnominatie in
+              description: Multiple values may be separated by commas.
+              type: array
+              items:
+                type: string
+              example: [ "blijvend_bewaren", "vernietigen" ]
+            archiefactiedatum:
+              title: Archiefactiedatum
+              description: De datum waarop het gearchiveerde zaakdossier vernietigd moet
+                worden dan wel overgebracht moet worden naar een archiefbewaarplaats.
+                Wordt automatisch berekend bij het aanmaken of wijzigen van een RESULTAAT
+                aan deze ZAAK indien nog leeg.
+              type: string
+              example: "2019-01-02"
+            archiefactiedatum__isnull:
+              title: Archiefactiedatum is leeg
+              type: boolean
+              example: false
+            archiefactiedatum__lt:
+              title: Archiefactiedatum kleiner dan
+              type: string
+              example: "2020-01-02"
+            archiefactiedatum__gt:
+              title: Archiefactiedatum  groter dan
+              type: string
+              example: "2018-01-02"
+            archiefstatus:
+              title: Archiefstatus
+              description: 'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+                termijn vernietigd moet worden.
+                Uitleg bij mogelijke waarden:
+                * `nog_te_archiveren` - De zaak cq. het zaakdossier is nog niet als geheel
+                gearchiveerd.
+                * `gearchiveerd` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar
+                bewaarbaar gemaakt.
+                * `gearchiveerd_procestermijn_onbekend` - De zaak cq. het zaakdossier
+                is als geheel niet-wijzigbaar bewaarbaar gemaakt maar de vernietigingsdatum
+                kan nog niet bepaald worden.
+                * `overgedragen` - De zaak cq. het zaakdossier is overgebracht naar een
+                archiefbewaarplaats.'
+              type: string
+              enum:
+              - nog_te_archiveren
+              - gearchiveerd
+              - gearchiveerd_procestermijn_onbekend
+              - overgedragen
+              example: "nog_te_archiveren"
+            archiefstatus__in:
+              title: Archiefstatus in
+              description: Multiple values may be separated by commas.
+              type: array
+              items:
+                type: string
+              example: [ "nog_te_archiveren","gearchiveerd","gearchiveerd_procestermijn_onbekend","overgedragen" ]
+            startdatum:
+              title: Startdatum
+              description: De datum waarop met de uitvoering van de zaak is gestart
+              type: string
+              example: "2017-01-02"
+            startdatum__gt:
+              title: Startdatum groter dan
+              type: string
+              example: "2018-01-02"
+            startdatum__gte:
+              title: Startdatum groter dan of gelijk
+              type: string
+              example: "2016-01-02"
+            startdatum__lt:
+              title: Startdatum kleiner dan
+              type: string
+              example: "2018-01-02"
+            startdatum__lte:
+              title: Startdatum kleiner dan of gelijk
+              type: string
+              example: "2018-01-02"
+            registratiedatum:
+              title: Registratiedatum
+              description: De datum waarop de zaakbehandelende organisatie de ZAAK heeft geregistreerd. Indien deze niet opgegeven wordt, wordt de datum van vandaag gebruikt.
+              type: string
+              example: "2015-01-02"
+            registratiedatum__gt:
+              title: Registratiedatum groter dan
+              type: string
+              example: "2014-01-02"
+            registratiedatum__lt:
+              title: Registratiedatum kleiner dan
+              type: string
+              example: "2016-01-02"
+            einddatum:
+              title: Einddatum
+              description: De datum waarop de uitvoering van de zaak afgerond is.
+              type: string
+              example: "2022-01-02"
+            einddatum__isnull:
+              title: Einddatum is leeg
+              type: boolean
+              example: false
+            einddatum__gt:
+              title: Einddatum groter dan
+              type: string
+              example: "2021-01-02"
+            einddatum__lt:
+              title: Einddatum kleiner dan
+              type: string
+              minLength: 1
+              example: "2023-01-02"
+            einddatumGepland:
+              title: Einddatum gepland
+              description: De datum waarop volgens de planning verwacht wordt dat de zaak afgerond wordt.
+              type: string
+              example: "2022-01-02"
+            einddatumGepland__gt:
+              title: Einddatum gepland groter dan
+              type: string
+              example: "2021-01-02"
+            einddatumGepland__lt:
+              title: Einddatum gepland kleiner dan
+              type: string
+              example: "2024-01-02"
+            uiterlijkeEinddatumAfdoening:
+              title: Uiterlijke einddatumAfdoening
+              description: De laatste datum waarop volgens wet- en regelgeving de zaak afgerond dient te zijn.
+              type: string
+              example: "2024-01-02"
+            uiterlijkeEinddatumAfdoening__gt:
+              title: Uiterlijke einddatumAfdoening groter dan
+              type: string
+              example: "2023-01-02"
+            uiterlijkeEinddatumAfdoening__lt:
+              title: Uiterlijke einddatumAfdoening kleiner dan
+              type: string
+              example: "2025-01-02"
+            rol__betrokkeneType:
+              title: Rol  betrokkenetype
+              description: 'Type van de `betrokkene`.
+                Uitleg bij mogelijke waarden:
+                * `natuurlijk_persoon` - Natuurlijk persoon
+                * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+                * `vestiging` - Vestiging
+                * `organisatorische_eenheid` - Organisatorische eenheid
+                * `medewerker` - Medewerker'
+              type: string
+              enum:
+              - natuurlijk_persoon
+              - niet_natuurlijk_persoon
+              - vestiging
+              - organisatorische_eenheid
+              - medewerker
+              example: "natuurlijk_persoon"
+            rol__betrokkene:
+              title: Rol  betrokkene
+              description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+              type: string
+              example: "https://example.com"
+            rol__omschrijvingGeneriek:
+              title: Rol  omschrijvinggeneriek
+              description:
+                Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.
+              type: string
+              enum:
+              - adviseur
+              - behandelaar
+              - belanghebbende
+              - beslisser
+              - initiator
+              - klantcontacter
+              - zaakcoordinator
+              - mede_initiator
+              example: "initiator"
+            maximaleVertrouwelijkheidaanduiding:
+              title: Maximalevertrouwelijkheidaanduiding
+              description:
+                Zaken met een vertrouwelijkheidaanduiding die beperkter is
+                dan de aangegeven aanduiding worden uit de resultaten gefiltered.
+              type: string
+              enum:
+              - openbaar
+              - beperkt_openbaar
+              - intern
+              - zaakvertrouwelijk
+              - vertrouwelijk
+              - confidentieel
+              - geheim
+              - zeer_geheim
+              example: "zaakvertrouwelijk"
+            rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn:
+              title: Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn
+              description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet
+                algemene bepalingen burgerservicenummer.
+              type: string
+              example: "123456789"
+            rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie:
+              title: Rol  betrokkeneidentificatie  natuurlijkpersoon  anpidentificatie
+              description: Het door de gemeente uitgegeven unieke nummer voor een ANDER
+                NATUURLIJK PERSOON
+              type: string
+              example: "123456789"
+            rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer:
+              title: Rol  betrokkeneidentificatie  natuurlijkpersoon  inpa nummer
+              description: Het administratienummer van de persoon, bedoeld in de Wet BRP
+              type: string
+              example: "123456789"
+            rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId:
+              title: Rol  betrokkeneidentificatie  nietnatuurlijkpersoon  innnnpid
+              description: Het door een kamer toegekend uniek nummer voor de INGESCHREVEN
+                NIET-NATUURLIJK PERSOON
+              type: string
+              example: "123456789"
+            rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie:
+              title: Rol  betrokkeneidentificatie  nietnatuurlijkpersoon  annidentificatie
+              description: Het door de gemeente uitgegeven unieke nummer voor een ANDER
+                NIET-NATUURLIJK PERSOON
+              type: string
+              example: "123456789"
+            rol__betrokkeneIdentificatie__vestiging__vestigingsNummer:
+              title: Rol  betrokkeneidentificatie  vestiging  vestigingsnummer
+              description: Een korte unieke aanduiding van de Vestiging.
+              type: string
+              example: "123456789"
+            rol__betrokkeneIdentificatie__medewerker__identificatie:
+              title: Rol  betrokkeneidentificatie  medewerker  identificatie
+              description: Een korte unieke aanduiding van de MEDEWERKER.
+              type: string
+              example: "123456789"
+            rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie:
+              title: Rol  betrokkeneidentificatie  organisatorischeeenheid  identificatie
+              description: Een korte identificatie van de organisatorische eenheid.
+              type: string
+              example: "123456789"
+            expand:
+              description: "Examples: \n`expand=zaaktype, status, status.statustype, hoofdzaak.status.statustype,` \
+                   \ hoofdzaak.deelzaken.status.statustype`Haal details van gelinkte resources direct op. 
+                   Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. 
+                   Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt."
+              title: expand
+              type: string
+              example: zaaktype, status, status.statustype, hoofdzaak.status.statustype, hoofdzaak.deelzaken.status.statustype              
+            ordering:
+              title: Ordering
+              description: Het veld waarop de resultaten geordend worden. Het minnetje betekent omgekeerde volgorde.
+              type: string
+              enum:
+              - startdatum
+              - -startdatum
+              - einddatum
+              - -einddatum
+              - publicatiedatum
+              - -publicatiedatum
+              - archiefactiedatum
+              - -archiefactiedatum
+              - registratiedatum
+              - -registratiedatum
+              - identificatie
+              - -identificatie
+              example: "-startdatum"
+    ZakelijkRechtHeeftAlsGerechtigde:
+      type: object
+      properties:
+        natuurlijkPersoon:
+          allOf:
+            - $ref: '#/components/schemas/RolNatuurlijkPersoon'
+          title: natuurlijkPersoon
+        nietNatuurlijkPersoon:
+          allOf:
+            - $ref: '#/components/schemas/RolNietNatuurlijkPersoon'
+          title: nietNatuurlijkPersoon
+    adres_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectAdres'
+    adres_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectAdres'
+    adres_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectAdres'
+    besluit_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+    besluit_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+    besluit_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+    betrokkene_identificatie_RolMedewerker:
+      type: object
+      properties:
+        betrokkeneIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolMedewerker'
+          title: betrokkeneIdentificatie
+    betrokkene_identificatie_RolNatuurlijkPersoon:
+      type: object
+      properties:
+        betrokkeneIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolNatuurlijkPersoon'
+          title: betrokkeneIdentificatie
+    betrokkene_identificatie_RolNietNatuurlijkPersoon:
+      type: object
+      properties:
+        betrokkeneIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolNietNatuurlijkPersoon'
+          title: betrokkeneIdentificatie
+    betrokkene_identificatie_RolOrganisatorischeEenheid:
+      type: object
+      properties:
+        betrokkeneIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolOrganisatorischeEenheid'
+          title: betrokkeneIdentificatie
+    betrokkene_identificatie_RolVestiging:
+      type: object
+      properties:
+        betrokkeneIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolVestiging'
+          title: betrokkeneIdentificatie
+    buurt_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectBuurt'
+    buurt_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectBuurt'
+    buurt_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectBuurt'
+    enkelvoudig_document_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+    enkelvoudig_document_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+    enkelvoudig_document_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+    gemeente_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeente'
+    gemeente_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeente'
+    gemeente_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeente'
+    gemeentelijke_openbare_ruimte_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeentelijkeOpenbareRuimte'
+    gemeentelijke_openbare_ruimte_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeentelijkeOpenbareRuimte'
+    gemeentelijke_openbare_ruimte_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeentelijkeOpenbareRuimte'
+    huishouden_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectHuishouden'
+    huishouden_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectHuishouden'
+    huishouden_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectHuishouden'
+    inrichtingselement_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectInrichtingselement'
+    inrichtingselement_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectInrichtingselement'
+    inrichtingselement_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectInrichtingselement'
+    kadastrale_onroerende_zaak_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKadastraleOnroerendeZaak'
+    kadastrale_onroerende_zaak_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKadastraleOnroerendeZaak'
+    kadastrale_onroerende_zaak_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKadastraleOnroerendeZaak'
+    kunstwerkdeel_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKunstwerkdeel'
+    kunstwerkdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKunstwerkdeel'
+    kunstwerkdeel_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKunstwerkdeel'
+    maatschappelijke_activiteit_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectMaatschappelijkeActiviteit'
+    maatschappelijke_activiteit_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectMaatschappelijkeActiviteit'
+    maatschappelijke_activiteit_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectMaatschappelijkeActiviteit'
+    medewerker_Rol:
+      allOf:
+        - $ref: '#/components/schemas/Rol'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    natuurlijk_persoon_Rol:
+      allOf:
+        - $ref: '#/components/schemas/Rol'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    niet_natuurlijk_persoon_Rol:
+      allOf:
+        - $ref: '#/components/schemas/Rol'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    object_identificatie_ObjectAdres:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectAdres'
+          title: objectIdentificatie
+    object_identificatie_ObjectBuurt:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectBuurt'
+          title: objectIdentificatie
+    object_identificatie_ObjectGemeente:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectGemeente'
+          title: objectIdentificatie
+    object_identificatie_ObjectGemeentelijkeOpenbareRuimte:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectGemeentelijkeOpenbareRuimte'
+          title: objectIdentificatie
+    object_identificatie_ObjectHuishouden:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectHuishouden'
+          title: objectIdentificatie
+    object_identificatie_ObjectInrichtingselement:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectInrichtingselement'
+          title: objectIdentificatie
+    object_identificatie_ObjectKadastraleOnroerendeZaak:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectKadastraleOnroerendeZaak'
+          title: objectIdentificatie
+    object_identificatie_ObjectKunstwerkdeel:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectKunstwerkdeel'
+          title: objectIdentificatie
+    object_identificatie_ObjectMaatschappelijkeActiviteit:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectMaatschappelijkeActiviteit'
+          title: objectIdentificatie
+    object_identificatie_ObjectOpenbareRuimte:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectOpenbareRuimte'
+          title: objectIdentificatie
+    object_identificatie_ObjectOverige:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectOverige'
+          title: objectIdentificatie
+    object_identificatie_ObjectPand:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectPand'
+          title: objectIdentificatie
+    object_identificatie_ObjectSpoorbaandeel:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectSpoorbaandeel'
+          title: objectIdentificatie
+    object_identificatie_ObjectTerreinGebouwdObject:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTerreinGebouwdObject'
+          title: objectIdentificatie
+    object_identificatie_ObjectTerreindeel:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTerreindeel'
+          title: objectIdentificatie
+    object_identificatie_ObjectWaterdeel:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWaterdeel'
+          title: objectIdentificatie
+    object_identificatie_ObjectWegdeel:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWegdeel'
+          title: objectIdentificatie
+    object_identificatie_ObjectWijk:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWijk'
+          title: objectIdentificatie
+    object_identificatie_ObjectWoonplaats:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWoonplaats'
+          title: objectIdentificatie
+    object_identificatie_ObjectWozDeelobject:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWozDeelobject'
+          title: objectIdentificatie
+    object_identificatie_ObjectWozObject:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWozObject'
+          title: objectIdentificatie
+    object_identificatie_ObjectWozWaarde:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWozWaarde'
+          title: objectIdentificatie
+    object_identificatie_ObjectZakelijkRecht:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectZakelijkRecht'
+          title: objectIdentificatie
+    object_identificatie_RolMedewerker:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolMedewerker'
+          title: objectIdentificatie
+    object_identificatie_RolNatuurlijkPersoon:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolNatuurlijkPersoon'
+          title: objectIdentificatie
+    object_identificatie_RolNietNatuurlijkPersoon:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolNietNatuurlijkPersoon'
+          title: objectIdentificatie
+    object_identificatie_RolOrganisatorischeEenheid:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolOrganisatorischeEenheid'
+          title: objectIdentificatie
+    object_identificatie_RolVestiging:
+      type: object
+      properties:
+        objectIdentificatie:
+          allOf:
+            - $ref: '#/components/schemas/RolVestiging'
+          title: objectIdentificatie
+    openbare_ruimte_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOpenbareRuimte'
+    openbare_ruimte_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOpenbareRuimte'
+    openbare_ruimte_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOpenbareRuimte'
+    organisatorische_eenheid_Rol:
+      allOf:
+        - $ref: '#/components/schemas/Rol'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    overige_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOverige'
+    overige_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOverige'
+    overige_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOverige'
+    pand_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectPand'
+    pand_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectPand'
+    pand_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectPand'
+    spoorbaandeel_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectSpoorbaandeel'
+    spoorbaandeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectSpoorbaandeel'
+    spoorbaandeel_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectSpoorbaandeel'
+    status_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+    status_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+    status_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+    terrein_gebouwd_object_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
+    terrein_gebouwd_object_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
+    terrein_gebouwd_object_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
+    terreindeel_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
+    terreindeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
+    terreindeel_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
+    vestiging_Rol:
+      allOf:
+        - $ref: '#/components/schemas/Rol'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    waterdeel_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'
+    waterdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'
+    waterdeel_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel' 
+    wegdeel_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
+    wegdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
+    wegdeel_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
+    wijk_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'
+    wijk_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'
+    wijk_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'   
+    woonplaats_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
+    woonplaats_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
+    woonplaats_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
+    woz_deelobject_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozDeelobject'
+    woz_deelobject_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozDeelobject'
+    woz_deelobject_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozDeelobject'
+    woz_object_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
+    woz_object_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
+    woz_object_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
+    woz_waarde_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozWaarde'
+    woz_waarde_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozWaarde'
+    woz_waarde_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozWaarde'
+    zakelijk_recht_ZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectZakelijkRecht'
+    zakelijk_recht_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectZakelijkRecht'
+    zakelijk_recht_PatchedZaakObject:
+      allOf:
+        - $ref: '#/components/schemas/PatchedZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectZakelijkRecht'
+  securitySchemes:
+    JWT-Claims:
+      type: http
+      bearerFormat: JWT
+      scheme: bearer
+servers:
+  - url: https://zaken-api.test.vng.cloud/api/v1
+  - url: https://zaken-api.vng.cloud/api/v1
+tags:
+  - name: klantcontacten
+    description: ''
+  - name: resultaten
+    description: ''
+  - name: rollen
+    description: ''
+  - name: statussen
+    description: ''
+  - name: zaakcontactmomenten
+    description: ''
+  - name: zaakinformatieobjecten
+    description: ''
+  - name: zaakobjecten
+    description: ''
+  - name: zaakverzoeken
+    description: ''
+  - name: zaken
+    description:
+      Een zaak mag (in principe) niet meer gewijzigd worden als de `archiefstatus`
+      een andere status heeft dan "nog_te_archiveren". Voor praktische redenen is er
+      geen harde validatie regel aan de provider kant.

--- a/api-specificatie/zrc/current_version/openapi.yaml
+++ b/api-specificatie/zrc/current_version/openapi.yaml
@@ -12418,11 +12418,6 @@ components:
             Omschrijving van het object, subject of gebeurtenis waarop,
             vanuit archiveringsoptiek, de zaak betrekking heeft.
           maxLength: 200
-        resultaattoelichting:
-          type: string
-          description: Een toelichting op wat het resultaat van de zaak inhoudt.
-          title: resultaattoelichting
-          maxLength: 1000
         startdatumBewaartermijn:
           type: string
           format: date
@@ -13071,13 +13066,14 @@ components:
           niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_Rol'
           organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_Rol'
           vestiging: '#/components/schemas/vestiging_Rol'
-    RolExpanded:
-     allOf:
-     - $ref: '#/components/schemas/Rol'
-     - properties:
-          _expand:
-            $ref: '#/components/schemas/RolEmbedded'
+    # RolExpanded:
+    #  allOf:
+    #  - $ref: '#/components/schemas/Rol'
+    #  - properties:
+    #       _expand:
+    #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14074,11 +14070,6 @@ components:
             Omschrijving van het object, subject of gebeurtenis waarop,
             vanuit archiveringsoptiek, de zaak betrekking heeft.
           maxLength: 200
-        resultaattoelichting:
-          type: string
-          description: Een toelichting op wat het resultaat van de zaak inhoudt.
-          title: resultaattoelichting
-          maxLength: 1000
         startdatumBewaartermijn:
           type: string
           format: date
@@ -14147,7 +14138,7 @@ components:
         rollen: 
           type: array
           items: 
-            $ref: '#/components/schemas/RolExpanded'   
+            $ref: '#/components/schemas/Rol'   
         status:
           oneOf:
           - $ref: '#/components/schemas/StatusExpanded'
@@ -14598,14 +14589,15 @@ components:
           woz_waarde: '#/components/schemas/woz_waarde_ZaakObject'
           zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObject'
           overige: '#/components/schemas/overige_ZaakObject'
-    ZaakObjectExpanded:
-      allOf:
-      - $ref: '#/components/schemas/ZaakObject'
-      - properties:
-            _expand:
-              $ref: '#/components/schemas/ZaakObjectEmbedded'
+    # ZaakObjectExpanded:
+    #   allOf:
+    #   - $ref: '#/components/schemas/ZaakObject'
+    #   - properties:
+    #         _expand:
+    #           $ref: '#/components/schemas/ZaakObjectEmbedded'
     ZaakObjectEmbedded:
       type: object
+      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'
@@ -14935,6 +14927,14 @@ components:
               description: Een korte identificatie van de organisatorische eenheid.
               type: string
               example: "123456789"
+            expand:
+              description: "Examples: \n`expand=zaaktype, status, status.statustype, hoofdzaak.status.statustype,` \
+                   \ hoofdzaak.deelzaken.status.statustype`Haal details van gelinkte resources direct op. 
+                   Als je meerdere resources tegelijk wilt ophalen kun je deze scheiden met een komma. 
+                   Voor het ophalen van resources die een laag dieper genest zijn wordt de punt-notatie gebruikt."
+              title: expand
+              type: string
+              example: zaaktype, status, status.statustype, hoofdzaak.status.statustype, hoofdzaak.deelzaken.status.statustype              
             ordering:
               title: Ordering
               description: Het veld waarop de resultaten geordend worden. Het minnetje betekent omgekeerde volgorde.

--- a/api-specificatie/zrc/current_version/openapi.yaml
+++ b/api-specificatie/zrc/current_version/openapi.yaml
@@ -13045,8 +13045,6 @@ components:
             dat STATUSsen in die ZAAK bereikt zijn.
           title: statussen
           uniqueItems: true
-        _expand:
-            $ref: '#/components/schemas/RolEmbedded'
       required:
         - betrokkeneType
         - omschrijving
@@ -13066,6 +13064,168 @@ components:
           niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_Rol'
           organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_Rol'
           vestiging: '#/components/schemas/vestiging_Rol'
+    RolExpanded:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        betrokkene:
+          type: string
+          format: uri
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          title: betrokkene
+          maxLength: 1000
+        betrokkeneType:
+          allOf:
+            - $ref: '#/components/schemas/BetrokkeneTypeEnum'
+          description: 'Type van de `betrokkene`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `vestiging` - Vestiging
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `medewerker` - Medewerker'
+          title: betrokkene type
+        afwijkendeNaamBetrokkene:
+          type: string
+          description:
+            De naam van de betrokkene waaronder deze in relatie tot de
+            zaak aangesproken wil worden.
+          title: afwijkende naam betrokkene
+          maxLength: 625
+        roltype:
+          type: string
+          format: uri
+          description:
+            URL-referentie naar een roltype binnen het ZAAKTYPE van de
+            ZAAK.
+          title: roltype
+          maxLength: 1000
+        omschrijving:
+          type: string
+          readOnly: true
+          description: Omschrijving van de aard van de ROL, afgeleid uit het ROLTYPE.
+          title: omschrijving
+        omschrijvingGeneriek:
+          type: string
+          readOnly: true
+          description:
+            "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid\
+            \ uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` -\
+            \ (Adviseur) Kennis in dienst stellen van de behandeling van (een deel\
+            \ van) een zaak.\n* `behandelaar` - (Behandelaar) De vakinhoudelijke behandeling\
+            \ doen van (een deel van) een zaak.\n* `belanghebbende` - (Belanghebbende)\
+            \ Vanuit eigen en objectief belang rechtstreeks betrokken zijn bij de\
+            \ behandeling en/of de uitkomst van een zaak.\n* `beslisser` - (Beslisser)\
+            \ Nemen van besluiten die voor de uitkomst van een zaak noodzakelijk zijn.\n\
+            * `initiator` - (Initiator) Aanleiding geven tot de start van een zaak\
+            \ ..\n* `klantcontacter` - (Klantcontacter) Het eerste aanspreekpunt zijn\
+            \ voor vragen van burgers en bedrijven ..\n* `zaakcoordinator` - (Zaakco\xF6\
+            rdinator) Er voor zorg dragen dat de behandeling van de zaak in samenhang\
+            \ uitgevoerd wordt conform de daarover gemaakte afspraken.\n* `mede_initiator`\
+            \ - Mede-initiator"
+          title: omschrijving generiek
+        roltoelichting:
+          type: string
+          title: roltoelichting
+          maxLength: 1000
+        registratiedatum:
+          type: string
+          format: date-time
+          readOnly: true
+          description: De datum waarop dit object is geregistreerd.
+          title: registratiedatum
+        indicatieMachtiging:
+          description: 'Indicatie machtiging
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `gemachtigde` - De betrokkene in de rol bij de zaak is door een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen
+
+            * `machtiginggever` - De betrokkene in de rol bij de zaak heeft een andere
+            betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen'
+          title: indicatie machtiging
+          oneOf:
+            - $ref: '#/components/schemas/IndicatieMachtigingEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+        contactpersoonRol:
+          allOf:
+            - $ref: '#/components/schemas/ContactPersoonRol'
+          nullable: true
+          description:
+            De gegevens van de persoon die anderen desgevraagd in contact
+            brengt met medewerkers van de BETROKKENE, een NIET-NATUURLIJK PERSOON
+            of VESTIGING zijnde, of met BETROKKENE zelf, een NATUURLIJK PERSOON zijnde
+            , vanuit het belang van BETROKKENE in haar ROL bij een ZAAK.
+          title: contactpersoonRol
+        statussen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+            minLength: 1
+            maxLength: 1000
+          readOnly: true
+          description:
+            De BETROKKENE die in zijn/haar ROL in een ZAAK heeft geregistreerd
+            dat STATUSsen in die ZAAK bereikt zijn.
+          title: statussen
+          uniqueItems: true
+        _expand:
+            $ref: '#/components/schemas/RolEmbedded'
+      required:
+        - betrokkeneType
+        - omschrijving
+        - omschrijvingGeneriek
+        - registratiedatum
+        - roltoelichting
+        - roltype
+        - statussen
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: betrokkeneType
+        mapping:
+          medewerker: '#/components/schemas/medewerker_RolExpanded'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_RolExpanded'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_RolExpanded'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_RolExpanded'
+          vestiging: '#/components/schemas/vestiging_RolExpanded'
+
     # RolExpanded:
     #  allOf:
     #  - $ref: '#/components/schemas/Rol'
@@ -13073,7 +13233,6 @@ components:
     #       _expand:
     #         $ref: '#/components/schemas/RolEmbedded'
     RolEmbedded:
-      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/rollen` endpoint!**"
       type: object
       properties: 
         zaak:
@@ -14138,7 +14297,7 @@ components:
         rollen: 
           type: array
           items: 
-            $ref: '#/components/schemas/Rol'   
+            $ref: '#/components/schemas/RolExpanded'   
         status:
           oneOf:
           - $ref: '#/components/schemas/StatusExpanded'
@@ -14146,7 +14305,7 @@ components:
         zaakobjecten:
           type: array
           items: 
-           $ref: '#/components/schemas/ZaakObject'
+           $ref: '#/components/schemas/ZaakObjectExpanded'
         resultaat:
           oneOf:
           - $ref: '#/components/schemas/ResultaatExpanded'
@@ -14548,8 +14707,6 @@ components:
           description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
           title: relatieomschrijving
           maxLength: 80
-        _expand:
-            $ref: '#/components/schemas/ZaakObjectEmbedded'
       required:
         - objectType
         - url
@@ -14589,15 +14746,198 @@ components:
           woz_waarde: '#/components/schemas/woz_waarde_ZaakObject'
           zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObject'
           overige: '#/components/schemas/overige_ZaakObject'
-    # ZaakObjectExpanded:
-    #   allOf:
-    #   - $ref: '#/components/schemas/ZaakObject'
-    #   - properties:
-    #         _expand:
-    #           $ref: '#/components/schemas/ZaakObjectEmbedded'
+    ZaakObjectExpanded:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+          title: url
+          description:
+            URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
+          minLength: 1
+          maxLength: 1000
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unieke resource identifier (UUID4)
+          title: uuid
+        zaak:
+          type: string
+          format: uri
+          description: URL-referentie naar de ZAAK.
+          title: zaak
+          minLength: 1
+          maxLength: 1000
+        object:
+          type: string
+          format: uri
+          description: URL-referentie naar de resource die het OBJECT beschrijft.
+          title: object
+          maxLength: 1000
+        zaakobjecttype:
+          type: string
+          format: uri
+          description: URL-referentie naar het ZAAKOBJECTTYPE (in de Catalogi API).
+          title: zaakobjecttype
+          maxLength: 1000
+        objectType:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeEnum'
+          description:
+            'Beschrijft het type OBJECT gerelateerd aan de ZAAK. Als er
+            geen passend type is, dan moet het type worden opgegeven onder `objectTypeOverige`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `adres` - Adres
+
+            * `besluit` - Besluit
+
+            * `buurt` - Buurt
+
+            * `enkelvoudig_document` - Enkelvoudig document
+
+            * `gemeente` - Gemeente
+
+            * `gemeentelijke_openbare_ruimte` - Gemeentelijke openbare ruimte
+
+            * `huishouden` - Huishouden
+
+            * `inrichtingselement` - Inrichtingselement
+
+            * `kadastrale_onroerende_zaak` - Kadastrale onroerende zaak
+
+            * `kunstwerkdeel` - Kunstwerkdeel
+
+            * `maatschappelijke_activiteit` - Maatschappelijke activiteit
+
+            * `medewerker` - Medewerker
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `openbare_ruimte` - Openbare ruimte
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `pand` - Pand
+
+            * `spoorbaandeel` - Spoorbaandeel
+
+            * `status` - Status
+
+            * `terreindeel` - Terreindeel
+
+            * `terrein_gebouwd_object` - Terrein gebouwd object
+
+            * `vestiging` - Vestiging
+
+            * `waterdeel` - Waterdeel
+
+            * `wegdeel` - Wegdeel
+
+            * `wijk` - Wijk
+
+            * `woonplaats` - Woonplaats
+
+            * `woz_deelobject` - Woz deel object
+
+            * `woz_object` - Woz object
+
+            * `woz_waarde` - Woz waarde
+
+            * `zakelijk_recht` - Zakelijk recht
+
+            * `overige` - Overige'
+          title: object type
+        objectTypeOverige:
+          type: string
+          description:
+            Beschrijft het type OBJECT als `objectType` de waarde "overige"
+            heeft.
+          title: object type overige
+          pattern: '[a-z\_]+'
+          maxLength: 100
+        objectTypeOverigeDefinitie:
+          allOf:
+            - $ref: '#/components/schemas/ObjectTypeOverigeDefinitie'
+          nullable: true
+          title: definitie object type overige
+          description:
+            'Verwijzing naar het schema van het type OBJECT als `objectType`
+            de waarde "overige" heeft.
+
+
+            * De URL referentie moet naar een JSON endpoint   wijzen waarin het objecttype
+            gedefinieerd is, inclusief het   [JSON-schema](https://json-schema.org/).
+
+            * Gebruik het `schema` attribuut om te verwijzen naar het schema binnen   de
+            objecttype resource (deze gebruikt het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+            * Gebruik het `objectData` attribuut om te verwijzen naar de gegevens   binnen
+            het OBJECT. Deze gebruikt ook het   [jq](http://stedolan.github.io/jq/)
+            formaat.
+
+
+            Indien je hier gebruikt van maakt, dan moet je een OBJECT url opgeven
+            en is het gebruik van objectIdentificatie niet mogelijk. De opgegeven
+            OBJECT url wordt gevalideerd tegen het schema van het opgegeven objecttype.'
+        relatieomschrijving:
+          type: string
+          description: Omschrijving van de betrekking tussen de ZAAK en het OBJECT.
+          title: relatieomschrijving
+          maxLength: 80
+        _expand:
+            $ref: '#/components/schemas/ZaakObjectEmbedded'
+      required:
+        - objectType
+        - url
+        - uuid
+        - zaak
+      discriminator:
+        propertyName: objectType
+        mapping:
+          adres: '#/components/schemas/adres_ZaakObjectExpanded'
+          besluit: '#/components/schemas/besluit_ZaakObjectExpanded'
+          buurt: '#/components/schemas/buurt_ZaakObjectExpanded'
+          enkelvoudig_document: '#/components/schemas/enkelvoudig_document_ZaakObjectExpanded'
+          gemeente: '#/components/schemas/gemeente_ZaakObjectExpanded'
+          gemeentelijke_openbare_ruimte: '#/components/schemas/gemeentelijke_openbare_ruimte_ZaakObjectExpanded'
+          huishouden: '#/components/schemas/huishouden_ZaakObjectExpanded'
+          inrichtingselement: '#/components/schemas/inrichtingselement_ZaakObjectExpanded'
+          kadastrale_onroerende_zaak: '#/components/schemas/kadastrale_onroerende_zaak_ZaakObjectExpanded'
+          kunstwerkdeel: '#/components/schemas/kunstwerkdeel_ZaakObjectExpanded'
+          maatschappelijke_activiteit: '#/components/schemas/maatschappelijke_activiteit_ZaakObjectExpanded'
+          medewerker: '#/components/schemas/medewerker_ZaakObjectExpanded'
+          natuurlijk_persoon: '#/components/schemas/natuurlijk_persoon_ZaakObjectExpanded'
+          niet_natuurlijk_persoon: '#/components/schemas/niet_natuurlijk_persoon_ZaakObjectExpanded'
+          openbare_ruimte: '#/components/schemas/openbare_ruimte_ZaakObjectExpanded'
+          organisatorische_eenheid: '#/components/schemas/organisatorische_eenheid_ZaakObjectExpanded'
+          pand: '#/components/schemas/pand_ZaakObjectExpanded'
+          spoorbaandeel: '#/components/schemas/spoorbaandeel_ZaakObjectExpanded'
+          status: '#/components/schemas/status_ZaakObjectExpanded'
+          terreindeel: '#/components/schemas/terreindeel_ZaakObjectExpanded'
+          terrein_gebouwd_object: '#/components/schemas/terrein_gebouwd_object_ZaakObjectExpanded'
+          vestiging: '#/components/schemas/vestiging_ZaakObjectExpanded'
+          waterdeel: '#/components/schemas/waterdeel_ZaakObjectExpanded'
+          wegdeel: '#/components/schemas/wegdeel_ZaakObjectExpanded'
+          wijk: '#/components/schemas/wijk_ZaakObjectExpanded'
+          woonplaats: '#/components/schemas/woonplaats_ZaakObjectExpanded'
+          woz_deelobject: '#/components/schemas/woz_deelobject_ZaakObjectExpanded'
+          woz_object: '#/components/schemas/woz_object_ZaakObjectExpanded'
+          woz_waarde: '#/components/schemas/woz_waarde_ZaakObjectExpanded'
+          zakelijk_recht: '#/components/schemas/zakelijk_recht_ZaakObjectExpanded'
+          overige: '#/components/schemas/overige_ZaakObjectExpanded'
     ZaakObjectEmbedded:
       type: object
-      description: "**LET OP: Deze expand kan alleen worden toegepast op het `/zaken` endpoint en niet op het `/zaakobjecten` endpoint!**"
       properties: 
         zaakobjecttype:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/master/api-specificatie/ztc/current_version/openapi.yaml#/components/schemas/ZaakObjectType'
@@ -14968,6 +15308,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectAdres'
+    adres_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectAdres'
     adres_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -14975,6 +15319,9 @@ components:
     besluit_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+    besluit_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
     besluit_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15017,6 +15364,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectBuurt'
+    buurt_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectBuurt'
     buurt_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15024,12 +15375,19 @@ components:
     enkelvoudig_document_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+    enkelvoudig_document_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
     enkelvoudig_document_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
     gemeente_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeente'
+    gemeente_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectGemeente'
     gemeente_PatchedZaakObject:
       allOf:
@@ -15039,6 +15397,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectGemeentelijkeOpenbareRuimte'
+    gemeentelijke_openbare_ruimte_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectGemeentelijkeOpenbareRuimte'
     gemeentelijke_openbare_ruimte_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15046,6 +15408,10 @@ components:
     huishouden_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectHuishouden'
+    huishouden_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectHuishouden'
     huishouden_PatchedZaakObject:
       allOf:
@@ -15055,6 +15421,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectInrichtingselement'
+    inrichtingselement_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectInrichtingselement'
     inrichtingselement_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15062,6 +15432,10 @@ components:
     kadastrale_onroerende_zaak_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKadastraleOnroerendeZaak'
+    kadastrale_onroerende_zaak_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectKadastraleOnroerendeZaak'
     kadastrale_onroerende_zaak_PatchedZaakObject:
       allOf:
@@ -15071,6 +15445,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectKunstwerkdeel'
+    kunstwerkdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectKunstwerkdeel'
     kunstwerkdeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15078,6 +15456,10 @@ components:
     maatschappelijke_activiteit_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectMaatschappelijkeActiviteit'
+    maatschappelijke_activiteit_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectMaatschappelijkeActiviteit'
     maatschappelijke_activiteit_PatchedZaakObject:
       allOf:
@@ -15087,9 +15469,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
     medewerker_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
+    medewerker_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolMedewerker'
     medewerker_PatchedZaakObject:
       allOf:
@@ -15099,9 +15489,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
     natuurlijk_persoon_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
+    natuurlijk_persoon_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNatuurlijkPersoon'
     natuurlijk_persoon_PatchedZaakObject:
       allOf:
@@ -15111,9 +15509,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
     niet_natuurlijk_persoon_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
+    niet_natuurlijk_persoon_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolNietNatuurlijkPersoon'
     niet_natuurlijk_persoon_PatchedZaakObject:
       allOf:
@@ -15319,6 +15725,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectOpenbareRuimte'
+    openbare_ruimte_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOpenbareRuimte'
     openbare_ruimte_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15327,9 +15737,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
     organisatorische_eenheid_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
+    organisatorische_eenheid_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolOrganisatorischeEenheid'
     organisatorische_eenheid_PatchedZaakObject:
       allOf:
@@ -15339,6 +15757,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectOverige'
+    overige_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectOverige'
     overige_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15346,6 +15768,10 @@ components:
     pand_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectPand'
+    pand_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectPand'
     pand_PatchedZaakObject:
       allOf:
@@ -15355,6 +15781,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectSpoorbaandeel'
+    spoorbaandeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectSpoorbaandeel'
     spoorbaandeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
@@ -15362,32 +15792,51 @@ components:
     status_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+    status_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
     status_PatchedZaakObject:
       allOf:
-        - $ref: '#/components/schemas/PatchedZaakObject'    
+        - $ref: '#/components/schemas/PatchedZaakObject'
     terrein_gebouwd_object_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
+    terrein_gebouwd_object_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
     terrein_gebouwd_object_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreinGebouwdObject'
     terreindeel_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
+    terreindeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
     terreindeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectTerreindeel'
     vestiging_Rol:
       allOf:
         - $ref: '#/components/schemas/Rol'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_RolExpanded:
+      allOf:
+        - $ref: '#/components/schemas/RolExpanded'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
     vestiging_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
+    vestiging_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/betrokkene_identificatie_RolVestiging'
     vestiging_PatchedZaakObject:
       allOf:
@@ -15397,37 +15846,57 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'
+    waterdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'
     waterdeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWaterdeel' 
     wegdeel_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
+    wegdeel_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
     wegdeel_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWegdeel'
     wijk_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWijk'
+    wijk_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'
     wijk_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWijk'   
     woonplaats_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
+    woonplaats_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
     woonplaats_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWoonplaats'
     woz_deelobject_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozDeelobject'
+    woz_deelobject_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectWozDeelobject'
     woz_deelobject_PatchedZaakObject:
       allOf:
@@ -15437,13 +15906,21 @@ components:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
         - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
+    woz_object_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
     woz_object_PatchedZaakObject:
       allOf:
         - $ref: '#/components/schemas/PatchedZaakObject'
-        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'    
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozObject'
     woz_waarde_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectWozWaarde'
+    woz_waarde_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectWozWaarde'
     woz_waarde_PatchedZaakObject:
       allOf:
@@ -15452,6 +15929,10 @@ components:
     zakelijk_recht_ZaakObject:
       allOf:
         - $ref: '#/components/schemas/ZaakObject'
+        - $ref: '#/components/schemas/object_identificatie_ObjectZakelijkRecht'
+    zakelijk_recht_ZaakObjectExpanded:
+      allOf:
+        - $ref: '#/components/schemas/ZaakObjectExpanded'
         - $ref: '#/components/schemas/object_identificatie_ObjectZakelijkRecht'
     zakelijk_recht_PatchedZaakObject:
       allOf:


### PR DESCRIPTION
N.a.v. issues #2412 en #2414. In de resources `rollen` en `zaakobjecten` komt het attribuut `_expand`  (onterecht) voor.  Dit is verwarrend want dit attribuut kan alleen indirect gebruikt worden via de `zaken` resource. In deze PR wordt dit attribuut verwijderd daar waar het niet van toepassing is. Deze correctie heeft geen functionele gevolgen.

Zie [redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/oplossen-expand-probleem/api-specificatie/zrc/1.5.x/1.5.1/openapi.yaml#) voor de gewijzigde OAS.

