### PR TITLE
Opmerking ingevoegd bij documentatie versie 1.5.0

### DIFF
--- a/docs/standaard/documenten/index.md
+++ b/docs/standaard/documenten/index.md
@@ -151,7 +151,7 @@ Versie   | Releasedatum | API specificatie
 [documenten-1.0.1-redoc]: redoc-1.0.1
 [documenten-1.0.1-swagger]: swagger-ui-1.0.1
 [documenten-1.0.1-diff]: https://github.com/VNG-Realisatie/documenten-api/compare/1.0.0...1.0.1?diff=split#diff-3dc0f8f7373b32ea3bf5eabe02993f9a
-[documenten-1.0.1-YAML](https://raw.githubusercontent.com/VNG-Realisatie/documenten-api/stable/1.0.x/src/openapi.yaml)
+[documenten-1.0.1-YAML]: https://raw.githubusercontent.com/VNG-Realisatie/documenten-api/stable/1.0.x/src/openapi.yaml
 
 [documenten-1.0.0-redoc]: ./redoc-1.0.0
 [documenten-1.0.0-swagger]: ./swagger-ui-1.0.0

--- a/docs/standaard/documenten/index.md
+++ b/docs/standaard/documenten/index.md
@@ -105,7 +105,7 @@ De [releasenotes](./release_notes.md) van de versies staan beschreven op deze [p
 
 Versie   | Releasedatum | API specificatie
 -------- | ------------- | ----------------
-1.5.0*   | 14-03-2024    | [ReDoc][documenten-1.5.0-redoc], [Swagger][documenten-1.5.0-swagger]
+1.5.0†   | 14-03-2024    | [ReDoc][documenten-1.5.0-redoc], [Swagger][documenten-1.5.0-swagger]
 1.4.3    | 27-10-2023    | [ReDoc][documenten-1.4.3-redoc], [Swagger][documenten-1.4.3-swagger]
 1.4.2    | 26-09-2023    | [ReDoc][documenten-1.4.2-redoc], [Swagger][documenten-1.4.2-swagger]
 1.3.2    | 26-09-2023    | [ReDoc][documenten-1.3.2-redoc], [Swagger][documenten-1.3.2-swagger]
@@ -120,7 +120,7 @@ Versie   | Releasedatum | API specificatie
 1.0.1    | 2019-12-16    | [ReDoc][documenten-1.0.1-redoc], [Swagger][documenten-1.0.1-swagger], [YAML](documenten-1.0.1-YAML), [Diff][documenten-1.0.1-diff]
 1.0.0    | 2019-11-18    | [ReDoc][documenten-1.0.0-redoc], [Swagger][documenten-1.0.0-swagger]
 
-*Let op: bij versie 1.5.0 is nog geen referentie-implementatie uitgebracht. Die volgt later in maart 2024.
+**†Let op: bij versie 1.5.0 is nog geen referentie-implementatie uitgebracht. Die volgt later in maart 2024.**
 
 [documenten-1.5.0-redoc]: ./redoc-1.5.0
 [documenten-1.5.0-swagger]: ./swagger-ui-1.5.0

--- a/docs/standaard/documenten/index.md
+++ b/docs/standaard/documenten/index.md
@@ -103,9 +103,9 @@ De [releasenotes](./release_notes.md) van de versies staan beschreven op deze [p
 
 ### Releases
 
-Versie   | Release datum | API specificatie
+Versie   | Releasedatum | API specificatie
 -------- | ------------- | ----------------
-1.5.0    | 14-03-2024    | [ReDoc][documenten-1.5.0-redoc], [Swagger][documenten-1.5.0-swagger]
+1.5.0*   | 14-03-2024    | [ReDoc][documenten-1.5.0-redoc], [Swagger][documenten-1.5.0-swagger]
 1.4.3    | 27-10-2023    | [ReDoc][documenten-1.4.3-redoc], [Swagger][documenten-1.4.3-swagger]
 1.4.2    | 26-09-2023    | [ReDoc][documenten-1.4.2-redoc], [Swagger][documenten-1.4.2-swagger]
 1.3.2    | 26-09-2023    | [ReDoc][documenten-1.3.2-redoc], [Swagger][documenten-1.3.2-swagger]
@@ -119,6 +119,8 @@ Versie   | Release datum | API specificatie
 1.1.0    | 24-05-2021    | [ReDoc][documenten-1.1.0-redoc], [Swagger][documenten-1.1.0-swagger], [YAML](documenten-1.1.0-YAML), [JSON](documenten-1.1.0-JSON), [Diff][documenten-1.1.0-diff]
 1.0.1    | 2019-12-16    | [ReDoc][documenten-1.0.1-redoc], [Swagger][documenten-1.0.1-swagger], [YAML](documenten-1.0.1-YAML), [Diff][documenten-1.0.1-diff]
 1.0.0    | 2019-11-18    | [ReDoc][documenten-1.0.0-redoc], [Swagger][documenten-1.0.0-swagger]
+
+*Let op: bij versie 1.5.0 is nog geen referentie-implementatie uitgebracht. Die volgt later in maart 2024.
 
 [documenten-1.5.0-redoc]: ./redoc-1.5.0
 [documenten-1.5.0-swagger]: ./swagger-ui-1.5.0

--- a/docs/standaard/documenten/release_notes.md
+++ b/docs/standaard/documenten/release_notes.md
@@ -8,7 +8,9 @@ layout: page-with-side-nav
 
 ## Versie 1.5.0
 
-Versie   | Release datum 
+**Let op: bij versie 1.5.0 is nog geen referentie-implementatie uitgebracht. Die volgt later in maart 2024. **
+
+Versie   | Releasedatum 
 -------- | ------------- 
 1.5.0    | 14-03-2024    
 
@@ -42,7 +44,7 @@ Het begrip 'vervallen' in deze indicatie moet gelezen worden als 'ongeldig gewor
 
 ## Versie 1.4.3
 
-Versie   | Release datum 
+Versie   | Releasedatum 
 -------- | ------------- 
 1.4.3    | 27-10-2023    
 
@@ -51,7 +53,7 @@ Versie   | Release datum
 
 ## Versies 1.4.2 / 1.3.2 / 1.2.5
 
-Versie   | Release datum 
+Versie   | Releasedatum 
 -------- | ------------- 
 1.4.2    | 26-09-2023    
 1.3.2    | 26-09-2023    
@@ -65,7 +67,7 @@ Versie   | Release datum
 
 ## Versies 1.4.1 / 1.3.1 / 1.2.4
 
-Versie   | Release datum 
+Versie   | Releasedatum 
 -------- | ------------- 
 1.4.1    | 29-08-2023    
 1.3.1    | 29-08-2023    
@@ -75,7 +77,7 @@ Versie   | Release datum
 
 ## Versie 1.4.0
 
-Versie   | Release datum 
+Versie   | Releasedatum 
 -------- | ------------- 
 1.4.0    | 22-08-2023    
 
@@ -85,7 +87,7 @@ Versie   | Release datum
 
 ## Versie 1.3.0
 
-Versie   | Release datum 
+Versie   | Releasedatum 
 -------- | ------------- 
 1.3.0    | 29-03-2023    
 
@@ -95,7 +97,7 @@ Versie   | Release datum
 
 ## Versie 1.2.0
 
-Versie   | Release datum 
+Versie   | Releasedatum 
 -------- | ------------- 
 1.2.0    | 19-12-2022    
 
@@ -107,7 +109,7 @@ Versie   | Release datum
 
 ## Versies 1.1.0 / 1.0.1 / 1.0.0  
 
-Versie   | Release datum 
+Versie   | Releasedatum 
 -------- | ------------- 
 1.1.0    | 24-05-2021    
 1.0.1    | 2019-12-16    

--- a/docs/standaard/documenten/release_notes.md
+++ b/docs/standaard/documenten/release_notes.md
@@ -8,7 +8,7 @@ layout: page-with-side-nav
 
 ## Versie 1.5.0
 
-**Let op: bij versie 1.5.0 is nog geen referentie-implementatie uitgebracht. Die volgt later in maart 2024. **
+**Let op: bij versie 1.5.0 is nog geen referentie-implementatie uitgebracht. Die volgt later in maart 2024.**
 
 Versie   | Releasedatum 
 -------- | ------------- 


### PR DESCRIPTION
over ontbrekende (en later volgende) referentie-implementatie bij deze versie