### PR TITLE
Verzoeken, Klanten en Contactmomenten API's documenteren als "niet meer in gebruik". 

### DIFF
--- a/docs/standaard/contactmomenten/index.md
+++ b/docs/standaard/contactmomenten/index.md
@@ -4,6 +4,12 @@ date: '14-7-2020'
 weight: 10
 layout: page-with-side-nav
 ---
+
+<span style="padding: 0.2em 0.5em; border: solid 1px #FF6600; border-radius: 3px; background: #FFFF99;">
+    <strong>Deze API is niet meer in gebruik</strong>
+</span>
+<br><br>
+
 # Contactmomenten API
 
 API voor opslag en ontsluiting van contactmomenten en daarbij behorende metadata.

--- a/docs/standaard/index.md
+++ b/docs/standaard/index.md
@@ -17,9 +17,9 @@ Hieronder de directe links naar de specificatie en documentatie van de API's:
 * [Autorisaties API specificatie](autorisaties/)
 * [Notificaties API specificatie](notificaties/)
 * [Notificaties API specificatie voor consumers](notificaties-consumer/)
-* [Contactmomenten API specificatie](contactmomenten/)
-* [Klanten API specificatie](klanten/)
-* [Verzoeken API specificatie](verzoeken/)
+* [Contactmomenten API specificatie](contactmomenten/) (_Niet meer in gebruik_)
+* [Klanten API specificatie](klanten/) (_Niet meer in gebruik_)
+* [Verzoeken API specificatie](verzoeken/) (_Niet meer in gebruik_)
 * [Referentielijsten en Selectielijst API][referentielijsten-1.0.0-redoc]
 
 [referentielijsten-1.0.0-redoc]: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/VNG-referentielijsten/master/src/openapi.yaml&nocors

--- a/docs/standaard/index.md
+++ b/docs/standaard/index.md
@@ -17,9 +17,9 @@ Hieronder de directe links naar de specificatie en documentatie van de API's:
 * [Autorisaties API specificatie](autorisaties/)
 * [Notificaties API specificatie](notificaties/)
 * [Notificaties API specificatie voor consumers](notificaties-consumer/)
-* [Contactmomenten API specificatie](contactmomenten/) (_Niet meer in gebruik_)
-* [Klanten API specificatie](klanten/) (_Niet meer in gebruik_)
-* [Verzoeken API specificatie](verzoeken/) (_Niet meer in gebruik_)
+* [Contactmomenten API specificatie](contactmomenten/) (_niet meer in gebruik_)
+* [Klanten API specificatie](klanten/) (_niet meer in gebruik_)
+* [Verzoeken API specificatie](verzoeken/) (_niet meer in gebruik_)
 * [Referentielijsten en Selectielijst API][referentielijsten-1.0.0-redoc]
 
 [referentielijsten-1.0.0-redoc]: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/VNG-referentielijsten/master/src/openapi.yaml&nocors

--- a/docs/standaard/klanten/index.md
+++ b/docs/standaard/klanten/index.md
@@ -4,6 +4,12 @@ date: '14-7-2020'
 weight: 10
 layout: page-with-side-nav
 ---
+
+<span style="padding: 0.2em 0.5em; border: solid 1px #FF6600; border-radius: 3px; background: #FFFF99;">
+    <strong>Deze API is niet meer in gebruik</strong>
+</span>
+<br><br>
+
 # Klanten API
 
 API voor opslag en ontsluiting van klanten en daarbij behorende metadata.

--- a/docs/standaard/klantinteracties/index.md
+++ b/docs/standaard/klantinteracties/index.md
@@ -4,9 +4,14 @@ date: '08-11-2019'
 weight: 10
 layout: page-with-side-nav
 ---
+
+<span style="padding: 0.2em 0.5em; border: solid 1px #FF6600; border-radius: 3px; background: #FFFF99;">
+    <strong>Deze API's zijn niet meer in gebruik</strong>
+</span>
+<br><br>
+
 # Klantinteracties API
 
-*Work in progress*
 
 De Klantinteractie API ondersteunt het opslaan en ontsluiten van contactmomenten en verzoeken. De component slaat deze gestructureerd op en stelt applicaties in staat deze te wijzigen en te verwijderen.
 

--- a/docs/standaard/verzoeken/index.md
+++ b/docs/standaard/verzoeken/index.md
@@ -4,6 +4,12 @@ date: '14-7-2020'
 weight: 10
 layout: page-with-side-nav
 ---
+
+<span style="padding: 0.2em 0.5em; border: solid 1px #FF6600; border-radius: 3px; background: #FFFF99;">
+    <strong>Deze API is niet meer in gebruik</strong>
+</span>
+<br><br>
+
 # Verzoeken API
 
 API voor opslag en ontsluiting van verzoeken en daarbij behorende metadata.


### PR DESCRIPTION
N.a.v. #2434 worden de Verzoeken, Klanten en Contactmomenten API's in de documentatie expliciet gedocumenteerd als "niet meer in gebruik". Nu is het verwarrend als je naar deze pagina gaat: https://vng-realisatie.github.io/gemma-zaken/standaard/