### PR TITLE
Adding a PUT-operation to `/rollen` endpoint in the Zaken API

### DIFF
--- a/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
@@ -2492,10 +2492,10 @@ paths:
                 'Geeft een specifieke API-versie aan in de context van
                 een specifieke aanroep. Voorbeeld: 1.2.1.'
           description: OK
-    patch:
-      operationId: rol_partial_update
-      summary: Werk een ROL deels bij.
-      description: Werk een ROL deels bij.
+    put:
+      operationId: rol_update
+      summary: Werk een ROL in zijn geheel bij.
+      description: Werk een ROL in zijn geheel bij.
       parameters:
         - in: path
           name: uuid

--- a/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
@@ -2492,6 +2492,235 @@ paths:
                 'Geeft een specifieke API-versie aan in de context van
                 een specifieke aanroep. Voorbeeld: 1.2.1.'
           description: OK
+    patch:
+      operationId: rol_partial_update
+      summary: Werk een ROL deels bij.
+      description: Werk een ROL deels bij.
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            type: string
+            format: uuid
+            description: Unieke resource identifier (UUID4)
+            title: uuid
+          required: true
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            enum:
+              - application/json
+          description: Content type van de verzoekinhoud.
+          required: true
+        - in: header
+          name: X-NLX-Logrecord-ID
+          schema:
+            type: string
+          description: Identifier of the request, traceable throughout the network
+        - in: header
+          name: X-Audit-Toelichting
+          schema:
+            type: string
+          description: Toelichting waarom een bepaald verzoek wordt gedaan
+        - in: header
+          name: Accept-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
+            in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
+            (EPSG:4326 is hetzelfde als WGS84).
+          required: true
+        - in: header
+          name: Content-Crs
+          schema:
+            type: string
+            enum:
+              - EPSG:4326
+          description:
+            Het 'Coordinate Reference System' (CRS) van de geometrie in de
+            vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
+            is hetzelfde als WGS84).
+          required: true
+      tags:
+        - rollen
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Rol'
+      security:
+        - JWT-Claims:
+            - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+      responses:
+        '200':
+          headers:
+            Content-Crs:
+              schema:
+                type: string
+                enum:
+                  - EPSG:4326
+              description:
+                Het 'Coordinate Reference System' (CRS) van de geometrie
+                in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default
+                (EPSG:4326 is hetzelfde als WGS84).
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rol'
+          description: OK
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '404':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not found
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description:
+                'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
   /statussen:
     get:
       operationId: status_list

--- a/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
+++ b/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml
@@ -2495,7 +2495,10 @@ paths:
     put:
       operationId: rol_update
       summary: Werk een ROL in zijn geheel bij.
-      description: Werk een ROL in zijn geheel bij.
+      description:
+         "**Er wordt gevalideerd op** \n- De attributen `zaak`, `betrokkene`\
+        \ en `betrokkeneType` mogen niet gewijzigd worden.\n- Indien opgegeven, dan wordt\
+        \ `betrokkeneIdentificatie` gevalideerd tegen de betrokkeneType discriminator."
       parameters:
         - in: path
           name: uuid


### PR DESCRIPTION
See issue #1835. You can view the changes [here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaken/zrc-rollen-update/api-specificatie/zrc/1.5.x/1.5.2/openapi.yaml&nocors#tag/rollen/operation/rol_update) with the Redoc Viewer.